### PR TITLE
BUGFIX: Autostart session upon authentication

### DIFF
--- a/Classes/Controller/AuthenticationController.php
+++ b/Classes/Controller/AuthenticationController.php
@@ -14,6 +14,7 @@ class AuthenticationController extends ActionController
     /**
      * trigger authentication again after user submitted second factor
      * @Flow\SkipCsrfProtection
+     * @Flow\Session(autoStart=true)
      */
     public function checkOtpAction()
     {


### PR DESCRIPTION
Adds a `@Flow\Session(autoStart=true)` annotation to the OTP authentication action
in order to start a session in case it hasn't been started already.

Fixes: #9