### PR TITLE
Allow doctrine migrations to be run on MySQL

### DIFF
--- a/Migrations/Mysql/Version20220207105522.php
+++ b/Migrations/Mysql/Version20220207105522.php
@@ -21,8 +21,8 @@ final class Version20220207105522 extends AbstractMigration
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf(
-            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MariaDb1027Platform,
-            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform'."
         );
 
         $this->addSql('CREATE TABLE sandstorm_neostwofactorauthentication_domain_model_secondfactor (persistence_object_identifier VARCHAR(40) NOT NULL, account VARCHAR(40) DEFAULT NULL, type INT NOT NULL, secret VARCHAR(255) NOT NULL, INDEX IDX_29EF8A7F7D3656A4 (account), PRIMARY KEY(persistence_object_identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
@@ -33,8 +33,8 @@ final class Version20220207105522 extends AbstractMigration
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf(
-            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MariaDb1027Platform,
-            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MariaDb1027Platform'."
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform'."
         );
 
         $this->addSql('DROP TABLE sandstorm_neostwofactorauthentication_domain_model_secondfactor');


### PR DESCRIPTION
Adjusts the platform check in the doctrine migration to be less strict and work for MySQL as well.
Note. `MariaDb1027Platform` extends `MySqlPlatform` so that this check still works for MariaDB, too.