### PR TITLE
fix: Use correct action to submit second factor

### DIFF
--- a/Resources/Private/Fusion/Presentation/Components/LoginSecondFactorStep.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/LoginSecondFactorStep.fusion
@@ -9,7 +9,7 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.LoginSecondFactorStep)
     }
 
     renderer = afx`
-        <Neos.Fusion.Form:Form form.target.action="checkOtp" form.target.controller="Login">
+        <Neos.Fusion.Form:Form form.target.action="checkSecondFactor" form.target.controller="Login">
             <fieldset>
                 <div class="neos-controls">
                     <Neos.Fusion.Form:Input


### PR DESCRIPTION
Hi,

thank you for open-sourcing this package! This PR fixes the form where the user enters their second factor. It currently uses action `checkOtp` in controller `Login`, but the action was recently renamed to `checkSecondFactor` (https://github.com/sandstorm/NeosTwoFactorAuthentication/blob/981446169a951948b637f9f13b2231e17d61e933/Classes/Controller/LoginController.php#L103). Currently (version 1.1.1), when the user enters their second factor and submits the form, they get redirected to the same form.