### PR TITLE
Option to enforce 2FA on specific users and/or Authentication Providers

### DIFF
--- a/Classes/Domain/Repository/SecondFactorRepository.php
+++ b/Classes/Domain/Repository/SecondFactorRepository.php
@@ -16,12 +16,6 @@ use Sandstorm\NeosTwoFactorAuthentication\Domain\Model\SecondFactor;
  */
 class SecondFactorRepository extends Repository
 {
-    public function isEnabledForAccount(Account $account): bool
-    {
-        $factors = $this->findByAccount($account);
-        return count($factors) > 0;
-    }
-
     /**
      * @throws IllegalObjectTypeException
      */

--- a/Classes/Http/Middleware/SecondFactorMiddleware.php
+++ b/Classes/Http/Middleware/SecondFactorMiddleware.php
@@ -15,7 +15,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 use Sandstorm\NeosTwoFactorAuthentication\Domain\AuthenticationStatus;
-use Sandstorm\NeosTwoFactorAuthentication\Domain\Repository\SecondFactorRepository;
+use Sandstorm\NeosTwoFactorAuthentication\Service\SecondFactorService;
 use Sandstorm\NeosTwoFactorAuthentication\Service\SecondFactorSessionStorageService;
 
 class SecondFactorMiddleware implements MiddlewareInterface
@@ -29,12 +29,6 @@ class SecondFactorMiddleware implements MiddlewareInterface
      * @var SecurityContext
      */
     protected $securityContext;
-
-    /**
-     * @Flow\Inject
-     * @var SecondFactorRepository
-     */
-    protected $secondFactorRepository;
 
     /**
      * @Flow\Inject
@@ -55,23 +49,10 @@ class SecondFactorMiddleware implements MiddlewareInterface
     protected $secondFactorSessionStorageService;
 
     /**
-     * @Flow\InjectConfiguration(path="enforceTwoFactorAuthentication")
-     * @var bool
+     * @Flow\Inject
+     * @var SecondFactorService
      */
-    protected $enforceTwoFactorAuthentication;
-
-    /**
-     * @Flow\InjectConfiguration(path="enforce2FAForAuthenticationProviders")
-     * @var array
-     */
-    protected $enforce2FAForAuthenticationProviders;
-
-    /**
-     * @Flow\InjectConfiguration(path="enforce2FAForRoles")
-     * @var array
-     */
-    protected $enforce2FAForRoles;
-
+    protected SecondFactorService $secondFactorService;
 
     /**
      * This middleware checks if the user is authenticated with a second factor "if necessary".
@@ -167,13 +148,11 @@ class SecondFactorMiddleware implements MiddlewareInterface
 
         $account = $this->securityContext->getAccount();
 
+        $isEnabledForAccount = $this->secondFactorService->isSecondFactorEnabledForAccount($account);
+        $isEnforcedForAccount = $this->secondFactorService->isSecondFactorEnforcedForAccount($account);
+
         // 4. Skip, if second factor is not set up for account and not enforced via settings.
-        if (
-            !$this->secondFactorRepository->isEnabledForAccount($account)
-            && !$this->enforceTwoFactorAuthentication
-            && !count(array_intersect(array_map(fn($item) => $item->getIdentifier(),$account->getRoles()),$this->enforce2FAForRoles))
-            && !in_array($account->getAuthenticationProviderName(),$this->enforce2FAForAuthenticationProviders)
-        ) {
+        if (!$isEnabledForAccount && !$isEnforcedForAccount) {
             $this->log('Second factor not enabled for account and not enforced by system, skipping second factor.');
 
             return $handler->handle($request);
@@ -193,7 +172,7 @@ class SecondFactorMiddleware implements MiddlewareInterface
         // 6. Redirect to 2FA login, if second factor is set up for account but not authenticated.
         //    Skip, if already on 2FA login route.
         if (
-            $this->secondFactorRepository->isEnabledForAccount($account)
+            $isEnabledForAccount
             && $authenticationStatus === AuthenticationStatus::AUTHENTICATION_NEEDED
         ) {
             // WHY: We use the request URI as state here to keep the middleware from entering a redirect loop.
@@ -213,13 +192,7 @@ class SecondFactorMiddleware implements MiddlewareInterface
 
         // 7. Redirect to 2FA setup, if second factor is not set up for account but is enforced by system.
         //    Skip, if already on 2FA setup route.
-        if (
-            ($this->enforceTwoFactorAuthentication
-             || count(array_intersect(array_map(fn($item) => $item->getIdentifier(),$account->getRoles()),$this->enforce2FAForRoles))
-             || in_array($account->getAuthenticationProviderName(),$this->enforce2FAForAuthenticationProviders)
-            )
-            && !$this->secondFactorRepository->isEnabledForAccount($account)
-        ) {
+        if ($isEnforcedForAccount && !$isEnabledForAccount) {
             // WHY: We use the request URI as state here to keep the middleware from entering a redirect loop.
             $isSettingUp2FA = str_ends_with($request->getUri()->getPath(), self::SECOND_FACTOR_SETUP_URI);
             if ($isSettingUp2FA) {

--- a/Classes/Service/SecondFactorService.php
+++ b/Classes/Service/SecondFactorService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Sandstorm\NeosTwoFactorAuthentication\Service;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Security\Account;
+use Sandstorm\NeosTwoFactorAuthentication\Domain\Repository\SecondFactorRepository;
+
+class SecondFactorService
+{
+    /**
+     * @Flow\InjectConfiguration(path="enforceTwoFactorAuthentication")
+     * @var bool
+     */
+    protected $enforceTwoFactorAuthentication;
+
+    /**
+     * @Flow\InjectConfiguration(path="enforce2FAForAuthenticationProviders")
+     * @var array
+     */
+    protected $enforce2FAForAuthenticationProviders;
+
+    /**
+     * @Flow\InjectConfiguration(path="enforce2FAForRoles")
+     * @var array
+     */
+    protected $enforce2FAForRoles;
+
+    /**
+     * @Flow\Inject
+     * @var SecondFactorRepository
+     */
+    protected $secondFactorRepository;
+
+    /**
+     * Check if the second factor is enforced for the given account.
+     *
+     * The second factor is enforced if:
+     *   - it is enforced for all accounts or
+     *   - it is enforced for a role of the account or
+     *   - it is enforced for the authentication provider of the account
+     */
+    public function isSecondFactorEnforcedForAccount(Account $account): bool
+    {
+        $isEnforcedForAll = $this->enforceTwoFactorAuthentication;
+        $isEnforcedForRoles = count(array_intersect(
+            array_map(fn($item) => $item->getIdentifier(), $account->getRoles()),
+            $this->enforce2FAForRoles
+        ));
+        $isEnforcedForAuthenticationProviders = in_array(
+            $account->getAuthenticationProviderName(),
+            $this->enforce2FAForAuthenticationProviders
+        );
+
+        return $isEnforcedForAll || $isEnforcedForRoles || $isEnforcedForAuthenticationProviders;
+    }
+
+    /**
+     * Check if the account has setup at least 1 second factor.
+     */
+    public function isSecondFactorEnabledForAccount(Account $account): bool
+    {
+        $factors = $this->secondFactorRepository->findByAccount($account);
+        return count($factors) > 0;
+    }
+
+    /**
+     * Check if the account can delete 1 second factor.
+     *
+     * Second factor can only be deleted if it is not enforced for the account or if the account has multiple factors.
+     */
+    public function canOneSecondFactorBeDeletedForAccount(Account $account): bool
+    {
+        $isEnforcedForAccount = $this->isSecondFactorEnforcedForAccount($account);
+        $hasMultipleFactors = count($this->secondFactorRepository->findByAccount($account)) > 1;
+
+        return !$isEnforcedForAccount || $hasMultipleFactors;
+    }
+}

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -45,6 +45,8 @@ Neos:
 Sandstorm:
   NeosTwoFactorAuthentication:
     # enforce 2FA for all users
-    enforceTwoFactorAuthentication: false
+    enforceTwoFactorAuthenticationForAllUserAccounts: false
+    enforceTwoFactorAuthenticationForAuthenticationProviders : []
+    enforceTwoFactorAuthenticationForSpecificUserAccounts: []
     # (optional) if set this will be used as a naming convention for the TOTP. If empty the Site name will be used
     issuerName: ''

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -45,8 +45,10 @@ Neos:
 Sandstorm:
   NeosTwoFactorAuthentication:
     # enforce 2FA for all users
-    enforceTwoFactorAuthenticationForAllUserAccounts: false
-    enforceTwoFactorAuthenticationForAuthenticationProviders : []
-    enforceTwoFactorAuthenticationForSpecificUserAccounts: []
+    enforceTwoFactorAuthentication: false
+    # enforce 2FA for specific authentication providers
+    enforce2FAForAuthenticationProviders : []
+    # enforce 2FA for specific roles
+    enforce2FAForRoles: []
     # (optional) if set this will be used as a naming convention for the TOTP. If empty the Site name will be used
     issuerName: ''

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Sandstorm:
 ```
 With this setting, no user can login into the CMS without setting up a second factor first.
 
+In addition, you can enforce 2FA for specific authentication providers and/or roles by adding following to your `Settings.yaml`
+```yml
+Sandstorm:
+    NeosTwoFactorAuthentication:
+      # enforce 2FA for specific authentication providers
+      enforce2FAForAuthenticationProviders : ['Neos.Neos:Backend']
+      # enforce 2FA for specific roles
+      enforce2FAForRoles: ['Neos.Neos:Administrator']  
+```
+
 ### Issuer Naming
 To override the default sitename as issuer label, you can define one via the configuration settings:
 ```yml


### PR DESCRIPTION
We use the OpenIDConnect extension where 2FA is enforced, but we also use the default Username-Password-Provider as a fallback and for all external users, with which we collaberate and which are not in our AD. 

For the latter group we would like to enforce this plugin. Hence, we extended the options to enforce 2FA for not only all users but also for specific users/authentication providers