### PR TITLE
FEATURE: Add creationDate to SecondFactor and ordering to second factor list in backend

### DIFF
--- a/Classes/Domain/Model/SecondFactor.php
+++ b/Classes/Domain/Model/SecondFactor.php
@@ -2,6 +2,7 @@
 
 namespace Sandstorm\NeosTwoFactorAuthentication\Domain\Model;
 
+use DateTime;
 use Neos\Flow\Http\InvalidArgumentException;
 use Neos\Flow\Security\Account;
 use Doctrine\ORM\Mapping as ORM;
@@ -39,10 +40,13 @@ class SecondFactor
     protected string $secret;
 
     /**
-     * @var \DateTime
-     * @ORM\Column(type="datetime", nullable=false)
+     * Introduced with version 1.4.0
+     * Nullable for backwards compatibility. Null values will be shown as '-' in backend module.
+     *
+     * @var DateTime|null
+     * @ORM\Column(type="datetime", nullable=true)
      */
-    protected \DateTime $creationDate;
+    protected DateTime|null $creationDate;
 
     /**
      * @return Account
@@ -100,12 +104,12 @@ class SecondFactor
         $this->secret = $secret;
     }
 
-    public function getCreationDate(): \DateTime
+    public function getCreationDate(): DateTime|null
     {
         return $this->creationDate;
     }
 
-    public function setCreationDate(\DateTime $creationDate): void
+    public function setCreationDate(DateTime $creationDate): void
     {
         $this->creationDate = $creationDate;
     }

--- a/Classes/Domain/Model/SecondFactor.php
+++ b/Classes/Domain/Model/SecondFactor.php
@@ -39,6 +39,12 @@ class SecondFactor
     protected string $secret;
 
     /**
+     * @var \DateTime
+     * @ORM\Column(type="datetime", nullable=false)
+     */
+    protected \DateTime $creationDate;
+
+    /**
      * @return Account
      */
     public function getAccount(): Account
@@ -92,6 +98,16 @@ class SecondFactor
     public function setSecret(string $secret): void
     {
         $this->secret = $secret;
+    }
+
+    public function getCreationDate(): \DateTime
+    {
+        return $this->creationDate;
+    }
+
+    public function setCreationDate(\DateTime $creationDate): void
+    {
+        $this->creationDate = $creationDate;
     }
 
     public function __toString(): string

--- a/Classes/Domain/Repository/SecondFactorRepository.php
+++ b/Classes/Domain/Repository/SecondFactorRepository.php
@@ -17,7 +17,7 @@ use Sandstorm\NeosTwoFactorAuthentication\Domain\Model\SecondFactor;
 class SecondFactorRepository extends Repository
 {
     protected $defaultOrderings = [
-        'account' => 'DESC',
+        'account' => 'ASC',
         'creationDate' => 'DESC'
     ];
 

--- a/Classes/Domain/Repository/SecondFactorRepository.php
+++ b/Classes/Domain/Repository/SecondFactorRepository.php
@@ -16,6 +16,11 @@ use Sandstorm\NeosTwoFactorAuthentication\Domain\Model\SecondFactor;
  */
 class SecondFactorRepository extends Repository
 {
+    protected $defaultOrderings = [
+        'account' => 'DESC',
+        'creationDate' => 'DESC'
+    ];
+
     /**
      * @throws IllegalObjectTypeException
      */
@@ -25,6 +30,7 @@ class SecondFactorRepository extends Repository
         $secondFactor->setAccount($account);
         $secondFactor->setSecret($secret);
         $secondFactor->setType(SecondFactor::TYPE_TOTP);
+        $secondFactor->setCreationDate(new \DateTime());
         $this->add($secondFactor);
         $this->persistenceManager->persistAll();
     }

--- a/Migrations/Mysql/Version20240812091514.php
+++ b/Migrations/Mysql/Version20240812091514.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240812091514 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform,'."
+        );
+
+        $this->addSql('ALTER TABLE sandstorm_neostwofactorauthentication_domain_model_secondfactor ADD creationdate DATETIME NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform,'."
+        );
+
+        $this->addSql('ALTER TABLE sandstorm_neostwofactorauthentication_domain_model_secondfactor DROP creationdate');
+    }
+}

--- a/Migrations/Mysql/Version20240812091514.php
+++ b/Migrations/Mysql/Version20240812091514.php
@@ -25,7 +25,7 @@ final class Version20240812091514 extends AbstractMigration
             "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform,'."
         );
 
-        $this->addSql('ALTER TABLE sandstorm_neostwofactorauthentication_domain_model_secondfactor ADD creationdate DATETIME NOT NULL');
+        $this->addSql('ALTER TABLE sandstorm_neostwofactorauthentication_domain_model_secondfactor ADD creationdate DATETIME DEFAULT NULL');
     }
 
     public function down(Schema $schema): void

--- a/Resources/Private/Fusion/Presentation/Components/SecondFactorList.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/SecondFactorList.fusion
@@ -7,6 +7,7 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.SecondFactorList) < pr
             <tr>
                 <th>{I18n.id('module.index.list.header.name').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</th>
                 <th>{I18n.id('module.index.list.header.type').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</th>
+                <th>{I18n.id('module.index.list.header.creationDate').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</th>
                 <th>&nbsp;</th>
             </tr>
             </thead>
@@ -42,6 +43,7 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.SecondFactorList.Entry
         <tr>
             <td>{props.factorAndPerson.user.name.fullName} ({props.factorAndPerson.secondFactor.account.accountIdentifier})</td>
             <td>{props.factorAndPerson.secondFactor.typeAsName}</td>
+            <td>{Date.format(props.factorAndPerson.secondFactor.creationDate, 'U') < 0 ? '-' : Date.format(props.factorAndPerson.secondFactor.creationDate, 'Y-m-d H:i')}</td>
             <td>
                 <button class="neos-button neos-button-danger" data-toggle="modal"
                         href={'#user-' + props.iterator.index} title={I18n.id('module.index.list.action.delete').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()} data-neos-toggle="tooltip">

--- a/Resources/Private/Fusion/Presentation/Components/SecondFactorList.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/SecondFactorList.fusion
@@ -43,7 +43,7 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.SecondFactorList.Entry
         <tr>
             <td>{props.factorAndPerson.user.name.fullName} ({props.factorAndPerson.secondFactor.account.accountIdentifier})</td>
             <td>{props.factorAndPerson.secondFactor.typeAsName}</td>
-            <td>{Date.format(props.factorAndPerson.secondFactor.creationDate, 'U') < 0 ? '-' : Date.format(props.factorAndPerson.secondFactor.creationDate, 'Y-m-d H:i')}</td>
+            <td>{props.factorAndPerson.secondFactor.creationDate == null ? '-' : Date.format(props.factorAndPerson.secondFactor.creationDate, 'Y-m-d H:i')}</td>
             <td>
                 <button class="neos-button neos-button-danger" data-toggle="modal"
                         href={'#user-' + props.iterator.index} title={I18n.id('module.index.list.action.delete').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()} data-neos-toggle="tooltip">

--- a/Resources/Private/Translations/de/Backend.xlf
+++ b/Resources/Private/Translations/de/Backend.xlf
@@ -23,6 +23,10 @@
         <source>Type</source>
         <target>Typ</target>
       </trans-unit>
+      <trans-unit id="module.index.list.header.creationDate" xml:space="preserve">
+        <source>Creation Date</source>
+        <target>Erstellungsdatum</target>
+      </trans-unit>
       <trans-unit id="module.index.list.action.delete" xml:space="preserve">
         <source>Delete second factor</source>
         <target>Zweiten Faktor löschen</target>

--- a/Resources/Private/Translations/en/Backend.xlf
+++ b/Resources/Private/Translations/en/Backend.xlf
@@ -18,6 +18,9 @@
       <trans-unit id="module.index.list.header.type" xml:space="preserve">
         <source>Type</source>
       </trans-unit>
+      <trans-unit id="module.index.list.header.creationDate" xml:space="preserve">
+        <source>Creation Date</source>
+      </trans-unit>
       <trans-unit id="module.index.list.action.delete" xml:space="preserve">
         <source>Delete second factor</source>
       </trans-unit>


### PR DESCRIPTION
This adds a `creationDate` field to the `SecondFactor` entity. It's always nice to have this information and we can order by it.

The default ordering in the backend module list is `account` descending and `creationDate` descending.

SecondFactors without a `creationDate` will get a default value.
The default value will be shown as '-' in the backend module list.

![Screenshot 2024-08-12 at 3 14 32 PM](https://github.com/user-attachments/assets/9ce17371-58c0-486b-a8bd-c7a5d55cb852)
