### PR TITLE
FEATURE: Raise version for spomky-labs/otphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "neos/fusion": "*",
         "neos/fusion-afx": "*",
         "neos/fusion-form": "*",
-        "spomky-labs/otphp": "^10.0",
+        "spomky-labs/otphp": "^11.0",
         "chillerlan/php-qrcode": "^4.3"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
- Bumps `spomky-labs/otphp` from `^10.0` to `^11.0` to resolve deprecation warnings from the outdated dependency

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)