### PR TITLE
TASK: Drop support for PHP <8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,13 @@
         "MIT"
     ],
     "require": {
-        "php": "^7.4 | ^8.0",
-        "neos/neos": "^5.3 | ^7.0 | ^8.0 | ^9.0",
+        "php": "^8.1",
+        "neos/neos": "^7.0 | ^8.0 | ^9.0",
         "neos/fusion": "*",
         "neos/fusion-afx": "*",
         "neos/fusion-form": "*",
         "spomky-labs/otphp": "^11.0",
-        "chillerlan/php-qrcode": "^4.3"
+        "chillerlan/php-qrcode": "^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
It's past time: #29

Also: #40.