### PR TITLE
✨ FEATURE: Add passkey support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,6 +51,10 @@ jobs:
         working-directory: Tests/E2E
         run: npm run test:${{ matrix.neos }}:enforce-provider
 
+      - name: Test - passwordless
+        working-directory: Tests/E2E
+        run: npm run test:${{ matrix.neos }}:passwordless
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,10 @@ jobs:
         working-directory: Tests/E2E
         run: npm run test:${{ matrix.neos }}:passwordless
 
+      - name: Test - enforce-all-passwordless
+        working-directory: Tests/E2E
+        run: npm run test:${{ matrix.neos }}:enforce-all-passwordless
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -87,6 +87,12 @@ class BackendController extends AbstractModuleController
     protected $persistenceManager;
 
     /**
+     * @Flow\InjectConfiguration(path="webAuthn.passwordlessLoginEnabled")
+     * @var bool
+     */
+    protected $passwordlessLoginEnabled = false;
+
+    /**
      * used to list all second factors of the current user
      */
     public function indexAction()
@@ -111,10 +117,31 @@ class BackendController extends AbstractModuleController
 
         $this->view->assignMultiple([
             'factorsAndPerson' => $factorsAndPerson,
+            'showRegisterPasskeyBanner' => $this->shouldNudgePasskeyRegistration($account),
             'flashMessages' => $this->flashMessageService
                 ->getFlashMessageContainerForRequest($this->request)
                 ->getMessagesAndFlush(),
         ]);
+    }
+
+    /**
+     * Whether to nudge the current user to register a passkey: only when passwordless login is
+     * enabled and the user does not yet have a discoverable (passwordless-capable) credential of
+     * their own. Non-discoverable "Passkey as 2nd factor" credentials do not count, as they cannot
+     * be used for passwordless login.
+     */
+    protected function shouldNudgePasskeyRegistration(\Neos\Flow\Security\Account $account): bool
+    {
+        if (!$this->passwordlessLoginEnabled) {
+            return false;
+        }
+        $ownPublicKeyFactors = $this->secondFactorRepository->findByAccountAndType($account, SecondFactor::TYPE_PUBLIC_KEY);
+        foreach ($ownPublicKeyFactors as $factor) {
+            if ($factor->isDiscoverable()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -117,7 +117,7 @@ class BackendController extends AbstractModuleController
 
         $this->view->assignMultiple([
             'factorsAndPerson' => $factorsAndPerson,
-            'showRegisterPasskeyBanner' => $this->shouldNudgePasskeyRegistration($account),
+            'showPasskeyRegistration' => $this->showPasskeyRegistration(),
             'flashMessages' => $this->flashMessageService
                 ->getFlashMessageContainerForRequest($this->request)
                 ->getMessagesAndFlush(),
@@ -125,23 +125,13 @@ class BackendController extends AbstractModuleController
     }
 
     /**
-     * Whether to nudge the current user to register a passkey: only when passwordless login is
-     * enabled and the user does not yet have a discoverable (passwordless-capable) credential of
-     * their own. Non-discoverable "Passkey as 2nd factor" credentials do not count, as they cannot
-     * be used for passwordless login.
+     * Whether to show the "Passkey Registration" section. Shown whenever passwordless login is
+     * enabled — a user may register several passwordless passkeys (e.g. a platform passkey plus a
+     * hardware key as backup), so the section stays available even after the first one.
      */
-    protected function shouldNudgePasskeyRegistration(\Neos\Flow\Security\Account $account): bool
+    protected function showPasskeyRegistration(): bool
     {
-        if (!$this->passwordlessLoginEnabled) {
-            return false;
-        }
-        $ownPublicKeyFactors = $this->secondFactorRepository->findByAccountAndType($account, SecondFactor::TYPE_PUBLIC_KEY);
-        foreach ($ownPublicKeyFactors as $factor) {
-            if ($factor->isDiscoverable()) {
-                return false;
-            }
-        }
-        return true;
+        return $this->passwordlessLoginEnabled;
     }
 
     /**
@@ -187,8 +177,13 @@ class BackendController extends AbstractModuleController
     /**
      * WebAuthn setup wizard. The JS on the page talks to LoginController's
      * webAuthnRegister(Options|Verify)Action XHR endpoints.
+     *
+     * @param bool $discoverable whether to register a discoverable passkey (reached from the
+     *                           "Passkey Registration" section) or a plain second factor (reached
+     *                           from the "Create second factor" method picker). The screen renders
+     *                           a single button accordingly.
      */
-    public function newWebAuthnAction(): void
+    public function newWebAuthnAction(bool $discoverable = false): void
     {
         $account = $this->securityContext->getAccount();
         $currentUser = $this->partyService->getAssignedPartyOfAccount($account);
@@ -196,6 +191,7 @@ class BackendController extends AbstractModuleController
         $this->view->assignMultiple([
             'currentUser' => $currentUser instanceof User ? $currentUser : null,
             'accountIdentifier' => $account->getAccountIdentifier(),
+            'discoverable' => $discoverable,
             'flashMessages' => $this->flashMessageService
                 ->getFlashMessageContainerForRequest($this->request)
                 ->getMessagesAndFlush(),

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -213,8 +213,13 @@ class LoginController extends ActionController
     /**
      * WebAuthn-specific setup wizard. The page loads JS which calls the
      * register-options and register-verify XHR endpoints.
+     *
+     * @param bool $discoverable whether to register a discoverable, passwordless-capable passkey
+     *                           rather than a plain second factor. Reaches here from the enforced
+     *                           method picker's "Register a passkey" option; only honoured when
+     *                           passwordless login is enabled (enforced server-side in WebAuthnService).
      */
-    public function setupWebAuthnAction(?string $username = null): void
+    public function setupWebAuthnAction(?string $username = null, bool $discoverable = false): void
     {
         $currentDomain = $this->domainRepository->findOneByActiveRequest();
         $currentSite = $currentDomain !== null ? $currentDomain->getSite() : $this->siteRepository->findDefault();
@@ -224,6 +229,7 @@ class LoginController extends ActionController
             'scripts' => array_filter($this->getNeosSettings()['userInterface']['backendLoginForm']['scripts']),
             'username' => $username,
             'site' => $currentSite,
+            'discoverable' => $discoverable,
             'redirectUrl' => $this->interceptedRequestOrBackendUri(),
             'flashMessages' => $this->flashMessageService
                 ->getFlashMessageContainerForRequest($this->request)

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -305,15 +305,19 @@ class LoginController extends ActionController
 
     /**
      * @Flow\SkipCsrfProtection
+     *
+     * @param bool $discoverable whether to register a discoverable passkey (passwordless-capable)
+     *                           rather than a plain second factor; only honoured when passwordless
+     *                           login is enabled.
      */
-    public function webAuthnRegisterOptionsAction(): string
+    public function webAuthnRegisterOptionsAction(bool $discoverable = false): string
     {
         $account = $this->securityContext->getAccount();
         if ($account === null) {
             return $this->jsonError('No authentication in progress', 401);
         }
         $hostname = $this->request->getHttpRequest()->getUri()->getHost();
-        $options = $this->webAuthnService->createRegistrationOptions($account, $hostname);
+        $options = $this->webAuthnService->createRegistrationOptions($account, $hostname, $discoverable);
         $this->secondFactorSessionStorageService->putValue(
             SecondFactorSessionStorageService::SESSION_OBJECT_WEBAUTHN_REGISTRATION_OPTIONS,
             json_encode($options, JSON_THROW_ON_ERROR)

--- a/Classes/Controller/PasswordlessLoginController.php
+++ b/Classes/Controller/PasswordlessLoginController.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Sandstorm\NeosTwoFactorAuthentication\Controller;
+
+/*
+ * This file is part of the Sandstorm.NeosTwoFactorAuthentication package.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ActionController;
+use Neos\Flow\Mvc\View\JsonView;
+use Neos\Flow\Security\Authentication\TokenInterface;
+use Neos\Flow\Security\Context as SecurityContext;
+use Sandstorm\NeosTwoFactorAuthentication\Domain\AuthenticationStatus;
+use Sandstorm\NeosTwoFactorAuthentication\Security\Token\WebAuthnPasswordlessToken;
+use Sandstorm\NeosTwoFactorAuthentication\Service\SecondFactorSessionStorageService;
+use Sandstorm\NeosTwoFactorAuthentication\Service\WebAuthnService;
+use Webauthn\PublicKeyCredentialRequestOptions;
+
+/**
+ * XHR endpoints for usernameless, passwordless passkey login from the Neos login screen.
+ *
+ * Both actions are reachable while logged out (this controller is intentionally NOT behind
+ * the Neos.Neos:Backend request pattern). They are hard-gated by the
+ * `webAuthn.passwordlessLoginEnabled` setting (off by default) so that, while disabled, no
+ * one can authenticate through this path even if the UI button were somehow present.
+ */
+class PasswordlessLoginController extends ActionController
+{
+    protected $supportedMediaTypes = ['application/json'];
+
+    protected $defaultViewObjectName = JsonView::class;
+
+    /**
+     * @Flow\Inject
+     * @var SecurityContext
+     */
+    protected $securityContext;
+
+    /**
+     * @Flow\Inject
+     * @var WebAuthnService
+     */
+    protected $webAuthnService;
+
+    /**
+     * @Flow\Inject
+     * @var SecondFactorSessionStorageService
+     */
+    protected $secondFactorSessionStorageService;
+
+    /**
+     * @Flow\InjectConfiguration(path="webAuthn.passwordlessLoginEnabled")
+     * @var bool
+     */
+    protected $passwordlessLoginEnabled = false;
+
+    /**
+     * Ceremony step 1: return the request options for navigator.credentials.get().
+     * Usernameless — no allowCredentials, so the browser offers any discoverable passkey.
+     *
+     * @Flow\SkipCsrfProtection
+     */
+    public function optionsAction(): string
+    {
+        if (!$this->passwordlessLoginEnabled) {
+            return $this->jsonError('Passwordless login is disabled', 403);
+        }
+        // The visitor is not authenticated yet, so no session exists — start one to hold the
+        // challenge across the options -> verify round trip.
+        $this->secondFactorSessionStorageService->startSessionIfNotStarted();
+        $hostname = $this->request->getHttpRequest()->getUri()->getHost();
+        $options = $this->webAuthnService->createPasswordlessAuthenticationOptions($hostname);
+        $this->secondFactorSessionStorageService->putValue(
+            SecondFactorSessionStorageService::SESSION_OBJECT_WEBAUTHN_PASSWORDLESS_OPTIONS,
+            json_encode($options, JSON_THROW_ON_ERROR)
+        );
+        $this->response->setContentType('application/json');
+        return json_encode($options, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Ceremony step 2: verify the assertion, resolve the account, authenticate the parallel
+     * WebAuthn token (which logs the user into the Neos backend without a password), and
+     * return the URI for the client to redirect to.
+     *
+     * @Flow\SkipCsrfProtection
+     */
+    public function verifyAction(string $assertion): string
+    {
+        if (!$this->passwordlessLoginEnabled) {
+            return $this->jsonError('Passwordless login is disabled', 403);
+        }
+
+        $serialized = $this->secondFactorSessionStorageService->getValue(
+            SecondFactorSessionStorageService::SESSION_OBJECT_WEBAUTHN_PASSWORDLESS_OPTIONS
+        );
+        if (!is_string($serialized)) {
+            return $this->jsonError('No passwordless login in progress', 400);
+        }
+        $options = PublicKeyCredentialRequestOptions::createFromString($serialized);
+
+        try {
+            $account = $this->webAuthnService->verifyPasswordlessAssertion(
+                $assertion,
+                $options,
+                $this->request->getHttpRequest()
+            );
+        } catch (\Throwable $e) {
+            return $this->jsonError($e->getMessage(), 400);
+        }
+
+        $token = $this->securityContext->getAuthenticationTokensOfType(WebAuthnPasswordlessToken::class)[0] ?? null;
+        if ($token === null) {
+            return $this->jsonError('Passwordless authentication token not available', 500);
+        }
+
+        // Authenticate the parallel token with the resolved backend account and persist it to
+        // the session so the authentication survives the redirect to the backend.
+        $token->setAccount($account);
+        $token->setAuthenticationStatus(TokenInterface::AUTHENTICATION_SUCCESSFUL);
+        $this->securityContext->refreshTokens();
+
+        // A user-verified passkey is itself multi-factor, so it also satisfies the 2FA gate.
+        $this->secondFactorSessionStorageService->initializeTwoFactorSessionObject();
+        $this->secondFactorSessionStorageService->setAuthenticationStatus(AuthenticationStatus::AUTHENTICATED);
+
+        $this->secondFactorSessionStorageService->removeValue(
+            SecondFactorSessionStorageService::SESSION_OBJECT_WEBAUTHN_PASSWORDLESS_OPTIONS
+        );
+
+        $this->response->setContentType('application/json');
+        return json_encode([
+            'status' => 'ok',
+            'redirect' => $this->interceptedRequestOrBackendUri(),
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    private function jsonError(string $message, int $code): string
+    {
+        $this->response->setStatusCode($code);
+        $this->response->setContentType('application/json');
+        return json_encode(['status' => 'error', 'message' => $message], JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Resolve the post-login redirect: the originally intercepted request if there is one,
+     * otherwise the Neos backend index — always through routing, never a hardcoded path.
+     */
+    private function interceptedRequestOrBackendUri(): string
+    {
+        $uriBuilder = $this->controllerContext->getUriBuilder();
+        $originalRequest = $this->securityContext->getInterceptedRequest();
+        if ($originalRequest !== null) {
+            return (string)$uriBuilder->uriFor(
+                $originalRequest->getControllerActionName(),
+                $originalRequest->getArguments(),
+                $originalRequest->getControllerName(),
+                $originalRequest->getControllerPackageKey()
+            );
+        }
+        return (string)$uriBuilder->uriFor('index', [], 'Backend\Backend', 'Neos.Neos');
+    }
+}

--- a/Classes/Domain/Model/SecondFactor.php
+++ b/Classes/Domain/Model/SecondFactor.php
@@ -60,6 +60,17 @@ class SecondFactor
     protected DateTime|null $creationDate;
 
     /**
+     * Whether this credential is a discoverable (resident) credential — a "Passkey" that can be
+     * used for passwordless login. Non-discoverable credentials work only as a second factor
+     * ("Passkey as 2nd factor"). Only meaningful for TYPE_PUBLIC_KEY; TOTP factors are never
+     * discoverable. Legacy rows registered before passkey support default to false.
+     *
+     * @var bool
+     * @ORM\Column(options={"default": false})
+     */
+    protected bool $discoverable = false;
+
+    /**
      * @return Account
      */
     public function getAccount(): Account
@@ -84,12 +95,29 @@ class SecondFactor
     }
 
     /**
-     * Used in Fusion rendering
+     * Used in Fusion rendering. For WebAuthn credentials the label distinguishes a
+     * passwordless-capable "Passkey" (discoverable) from a "Passkey as 2nd factor"
+     * (non-discoverable, e.g. a legacy security key or one registered while passwordless
+     * login was disabled).
+     *
      * @return string
      */
     public function getTypeAsName(): string
     {
+        if ($this->type === self::TYPE_PUBLIC_KEY) {
+            return $this->discoverable ? 'Passkey' : 'Passkey as 2nd factor';
+        }
         return self::typeToString($this->getType());
+    }
+
+    public function isDiscoverable(): bool
+    {
+        return $this->discoverable;
+    }
+
+    public function setDiscoverable(bool $discoverable): void
+    {
+        $this->discoverable = $discoverable;
     }
 
     /**
@@ -175,7 +203,7 @@ class SecondFactor
             case self::TYPE_TOTP:
                 return 'OTP code';
             case self::TYPE_PUBLIC_KEY:
-                return 'Security Key';
+                return 'Passkey';
             default:
                 throw new InvalidArgumentException('Unsupported second factor type with index ' . $type);
         }

--- a/Classes/Domain/Repository/SecondFactorRepository.php
+++ b/Classes/Domain/Repository/SecondFactorRepository.php
@@ -25,13 +25,14 @@ class SecondFactorRepository extends Repository
     /**
      * @throws IllegalObjectTypeException
      */
-    public function createSecondFactorForAccount(string $secret, Account $account, int $type = SecondFactor::TYPE_TOTP, string $name = ''): SecondFactor
+    public function createSecondFactorForAccount(string $secret, Account $account, int $type = SecondFactor::TYPE_TOTP, string $name = '', bool $discoverable = false): SecondFactor
     {
         $secondFactor = new SecondFactor();
         $secondFactor->setAccount($account);
         $secondFactor->setSecret($secret);
         $secondFactor->setType($type);
         $secondFactor->setName($name);
+        $secondFactor->setDiscoverable($discoverable);
         $secondFactor->setCreationDate(new \DateTime());
         $this->add($secondFactor);
         $this->persistenceManager->persistAll();

--- a/Classes/Security/Authentication/WebAuthnPasswordlessProvider.php
+++ b/Classes/Security/Authentication/WebAuthnPasswordlessProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Sandstorm\NeosTwoFactorAuthentication\Security\Authentication;
+
+use Neos\Flow\Security\Authentication\Provider\AbstractProvider;
+use Neos\Flow\Security\Authentication\TokenInterface;
+use Sandstorm\NeosTwoFactorAuthentication\Security\Token\WebAuthnPasswordlessToken;
+
+/**
+ * Authentication provider for usernameless passwordless passkey login.
+ *
+ * The actual WebAuthn verification and token authentication happen in the
+ * {@see \Sandstorm\NeosTwoFactorAuthentication\Controller\PasswordlessLoginController}
+ * (it needs the session-stored challenge and the webauthn-lib validator). This provider
+ * exists so the framework registers the {@see WebAuthnPasswordlessToken} for this provider
+ * name, keeps it active (no request pattern), and restores it from the session on later
+ * requests. With the `oneToken` authentication strategy, an authenticated parallel token is
+ * enough for the request to count as authenticated; the resolved account is a regular
+ * `Neos.Neos:Backend` account, so roles and the current Neos user resolve normally.
+ */
+class WebAuthnPasswordlessProvider extends AbstractProvider
+{
+    /**
+     * @return array<string>
+     */
+    public function getTokenClassNames()
+    {
+        return [WebAuthnPasswordlessToken::class];
+    }
+
+    /**
+     * The AuthenticationProviderManager only calls this for tokens in state
+     * AUTHENTICATION_NEEDED. The controller drives this token straight from
+     * NO_CREDENTIALS_GIVEN to AUTHENTICATION_SUCCESSFUL, so there is nothing to do here:
+     * never downgrade an already-successful (session-restored) token.
+     */
+    public function authenticate(TokenInterface $authenticationToken)
+    {
+        if (!$authenticationToken instanceof WebAuthnPasswordlessToken) {
+            return;
+        }
+        if ($authenticationToken->getAuthenticationStatus() !== TokenInterface::AUTHENTICATION_SUCCESSFUL) {
+            $authenticationToken->setAuthenticationStatus(TokenInterface::NO_CREDENTIALS_GIVEN);
+        }
+    }
+}

--- a/Classes/Security/Token/WebAuthnPasswordlessToken.php
+++ b/Classes/Security/Token/WebAuthnPasswordlessToken.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sandstorm\NeosTwoFactorAuthentication\Security\Token;
+
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Security\Authentication\Token\AbstractToken;
+
+/**
+ * Authentication token for usernameless, passwordless passkey login.
+ *
+ * Unlike the username/password token, this token carries no credentials extracted
+ * from the request: the WebAuthn assertion is verified by the
+ * {@see \Sandstorm\NeosTwoFactorAuthentication\Controller\PasswordlessLoginController},
+ * which then sets the resolved account on this token and marks it authenticated.
+ * {@see \Sandstorm\NeosTwoFactorAuthentication\Security\Authentication\WebAuthnPasswordlessProvider}
+ * is registered for this token so the framework instantiates and persists it.
+ */
+class WebAuthnPasswordlessToken extends AbstractToken
+{
+    /**
+     * No credentials are read from the request — the controller performs the WebAuthn
+     * ceremony and authenticates this token directly. Must NOT change the authentication
+     * status here, otherwise refreshTokens() (which calls updateCredentials on every active
+     * token) would reset a token the controller just authenticated.
+     */
+    public function updateCredentials(ActionRequest $actionRequest)
+    {
+    }
+}

--- a/Classes/Service/SecondFactorSessionStorageService.php
+++ b/Classes/Service/SecondFactorSessionStorageService.php
@@ -13,6 +13,7 @@ class SecondFactorSessionStorageService
     const SESSION_OBJECT_AUTH_STATUS = 'authenticationStatus';
     const SESSION_OBJECT_WEBAUTHN_REGISTRATION_OPTIONS = 'webAuthnRegistrationOptions';
     const SESSION_OBJECT_WEBAUTHN_AUTHENTICATION_OPTIONS = 'webAuthnAuthenticationOptions';
+    const SESSION_OBJECT_WEBAUTHN_PASSWORDLESS_OPTIONS = 'webAuthnPasswordlessOptions';
 
     /**
      * @Flow\Inject
@@ -65,14 +66,27 @@ class SecondFactorSessionStorageService
         $session->putData(self::SESSION_OBJECT_ID, $data);
     }
 
-    /**
-     * @throws SessionNotStartedException
-     */
     public function getValue(string $key): mixed
     {
         $session = $this->sessionManager->getCurrentSession();
+        if (!$session->isStarted()) {
+            return null;
+        }
         $data = $session->getData(self::SESSION_OBJECT_ID) ?: [];
         return $data[$key] ?? null;
+    }
+
+    /**
+     * Start the current session if it has not been started yet. Needed for the passwordless
+     * login flow, which runs for a not-yet-authenticated visitor (so, unlike the 2nd-factor
+     * flow, there is no session started by the preceding password authentication).
+     */
+    public function startSessionIfNotStarted(): void
+    {
+        $session = $this->sessionManager->getCurrentSession();
+        if (!$session->isStarted()) {
+            $session->start();
+        }
     }
 
     /**

--- a/Classes/Service/SecondFactorSessionStorageService.php
+++ b/Classes/Service/SecondFactorSessionStorageService.php
@@ -39,7 +39,10 @@ class SecondFactorSessionStorageService
     {
         $storageObject = $this->sessionManager->getCurrentSession()->getData(self::SESSION_OBJECT_ID);
 
-        return $storageObject[self::SESSION_OBJECT_AUTH_STATUS];
+        // The container may exist without an auth status: the passwordless login flow writes its
+        // options into the same container (via putValue) before any status is set. Treat a missing
+        // status as "not yet authenticated" instead of returning null and violating the return type.
+        return $storageObject[self::SESSION_OBJECT_AUTH_STATUS] ?? AuthenticationStatus::AUTHENTICATION_NEEDED;
     }
 
     /**
@@ -47,8 +50,13 @@ class SecondFactorSessionStorageService
      */
     public function initializeTwoFactorSessionObject(): void
     {
-        if (!$this->sessionManager->getCurrentSession()->hasKey(self::SESSION_OBJECT_ID)) {
-            self::setAuthenticationStatus(AuthenticationStatus::AUTHENTICATION_NEEDED);
+        // Gate on the auth status key, not merely the container's presence: the passwordless login
+        // flow populates the same container with its options (via putValue) before any status is
+        // written, so checking hasKey(SESSION_OBJECT_ID) would wrongly treat it as initialized and
+        // leave the status unset.
+        $data = $this->sessionManager->getCurrentSession()->getData(self::SESSION_OBJECT_ID) ?: [];
+        if (!isset($data[self::SESSION_OBJECT_AUTH_STATUS])) {
+            $this->setAuthenticationStatus(AuthenticationStatus::AUTHENTICATION_NEEDED);
         }
     }
 

--- a/Classes/Service/WebAuthnService.php
+++ b/Classes/Service/WebAuthnService.php
@@ -70,6 +70,12 @@ class WebAuthnService
     protected $securedRelyingPartyIds = [];
 
     /**
+     * @Flow\InjectConfiguration(path="webAuthn.passwordlessLoginEnabled")
+     * @var bool
+     */
+    protected $passwordlessLoginEnabled = false;
+
+    /**
      * `lazy=false` so the real adapter (not a DependencyProxy) is passed into the
      * web-auth validator constructors, which strict-type-hint the interface.
      *
@@ -121,6 +127,16 @@ class WebAuthnService
 
         $authenticatorSelection = AuthenticatorSelectionCriteria::create()
             ->setUserVerification($this->userVerification);
+
+        // When passwordless login is enabled, register discoverable (resident) credentials
+        // with user verification so a single credential works both for one-tap usernameless
+        // login AND as a strong second factor. When disabled the behaviour is unchanged, so
+        // U2F-only keys (which cannot store a resident credential) keep working as a 2nd factor.
+        if ($this->passwordlessLoginEnabled) {
+            $authenticatorSelection
+                ->setResidentKey(AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED)
+                ->setUserVerification(AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED);
+        }
 
         return PublicKeyCredentialCreationOptions::create(
             $rp,
@@ -214,6 +230,84 @@ class WebAuthnService
             $userHandle,
             $this->securedRelyingPartyIds
         );
+    }
+
+    /**
+     * Build request options for a usernameless (passwordless) login: no allowed
+     * credentials, so the browser offers any discoverable credential for this
+     * relying party, and user verification is required (a verified passkey is a
+     * full multi-factor authentication on its own).
+     */
+    public function createPasswordlessAuthenticationOptions(string $hostname): PublicKeyCredentialRequestOptions
+    {
+        return PublicKeyCredentialRequestOptions::create(random_bytes(32))
+            ->setTimeout($this->timeoutMs)
+            ->setRpId($this->relyingPartyId ?: $hostname)
+            ->setUserVerification(PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_REQUIRED);
+    }
+
+    /**
+     * Verify a usernameless assertion and resolve the Neos backend account it belongs to.
+     *
+     * The assertion carries both the credential id and a user handle. We look the credential
+     * up by its id first (proving we actually stored it), then let the library verify the
+     * assertion against that credential's stored user handle, and finally map the user handle
+     * (the account's persistence identifier) back to the Flow account. Only Neos backend
+     * accounts may use this login path.
+     *
+     * @throws \Throwable when validation fails or no matching backend account exists
+     */
+    public function verifyPasswordlessAssertion(
+        string $assertionResponseJson,
+        PublicKeyCredentialRequestOptions $options,
+        ServerRequestInterface $request
+    ): Account {
+        $publicKeyCredentialLoader = $this->buildCredentialLoader();
+        $publicKeyCredential = $publicKeyCredentialLoader->load($assertionResponseJson);
+        $authenticatorResponse = $publicKeyCredential->getResponse();
+        if (!$authenticatorResponse instanceof AuthenticatorAssertionResponse) {
+            throw new \RuntimeException('Response is not an AuthenticatorAssertionResponse', 1751200000);
+        }
+
+        $rawId = $publicKeyCredential->getRawId();
+        $credentialSource = $this->credentialSourceRepository->findOneByCredentialId($rawId);
+        if ($credentialSource === null) {
+            throw new \RuntimeException('Unknown passkey credential', 1751200001);
+        }
+
+        $userHandle = $credentialSource->getUserHandle();
+        $validator = $this->buildAssertionValidator();
+        $validator->check(
+            $rawId,
+            $authenticatorResponse,
+            $options,
+            $request,
+            $userHandle,
+            $this->securedRelyingPartyIds
+        );
+
+        return $this->resolveBackendAccountByUserHandle($userHandle);
+    }
+
+    /**
+     * Map a passkey user handle (the account's persistence identifier) back to its Flow account,
+     * guarding that it is a Neos backend account. Extracted so this security-critical mapping can
+     * be unit-tested without WebAuthn crypto.
+     *
+     * @throws \RuntimeException when no matching Neos backend account exists
+     */
+    public function resolveBackendAccountByUserHandle(string $userHandle): Account
+    {
+        $account = $this->persistenceManager->getObjectByIdentifier($userHandle, Account::class);
+        if (!$account instanceof Account) {
+            throw new \RuntimeException('No account found for the passkey user handle', 1751200002);
+        }
+        // Guard: only Neos backend accounts may authenticate passwordlessly through this path.
+        if ($account->getAuthenticationProviderName() !== 'Neos.Neos:Backend') {
+            throw new \RuntimeException('Passkey does not belong to a Neos backend account', 1751200003);
+        }
+
+        return $account;
     }
 
     private function buildUserEntity(Account $account): PublicKeyCredentialUserEntity

--- a/Classes/Service/WebAuthnService.php
+++ b/Classes/Service/WebAuthnService.php
@@ -99,8 +99,14 @@ class WebAuthnService
     /**
      * Build a registration options object that the browser passes to
      * `navigator.credentials.create()`.
+     *
+     * When $discoverable is true (and passwordless login is enabled) the credential is
+     * registered as a resident, user-verified passkey usable for passwordless login. Otherwise
+     * it is registered as a plain second factor: no resident key, and user verification follows
+     * the configured `webAuthn.userVerification` level — so a touch-only security key (no PIN)
+     * keeps working as a 2nd factor even while passwordless login is enabled.
      */
-    public function createRegistrationOptions(Account $account, string $hostname): PublicKeyCredentialCreationOptions
+    public function createRegistrationOptions(Account $account, string $hostname, bool $discoverable = false): PublicKeyCredentialCreationOptions
     {
         $rp = new PublicKeyCredentialRpEntity(
             $this->relyingPartyName ?: 'Neos',
@@ -128,11 +134,14 @@ class WebAuthnService
         $authenticatorSelection = AuthenticatorSelectionCriteria::create()
             ->setUserVerification($this->userVerification);
 
-        // When passwordless login is enabled, register discoverable (resident) credentials
-        // with user verification so a single credential works both for one-tap usernameless
-        // login AND as a strong second factor. When disabled the behaviour is unchanged, so
-        // U2F-only keys (which cannot store a resident credential) keep working as a 2nd factor.
-        if ($this->passwordlessLoginEnabled) {
+        // Register a discoverable (resident), user-verified passkey only when the user opted into
+        // it AND passwordless login is enabled — such a credential works both for one-tap
+        // usernameless login AND as a strong second factor. The guard means a discoverable
+        // credential can never be minted while passwordless login is off. Any other registration
+        // keeps the configured user-verification level and no resident-key requirement, so
+        // touch-only / U2F-only keys keep working as a plain 2nd factor.
+        $registerAsPasskey = $discoverable && $this->passwordlessLoginEnabled;
+        if ($registerAsPasskey) {
             $authenticatorSelection
                 ->setResidentKey(AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED)
                 ->setUserVerification(AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED);
@@ -148,6 +157,17 @@ class WebAuthnService
             ->setAuthenticatorSelection($authenticatorSelection)
             ->setAttestation(PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE)
             ->excludeCredentials(...$excludeCredentials);
+    }
+
+    /**
+     * Whether the given registration options describe a discoverable (resident) passkey. This is
+     * the single source of truth for the stored `discoverable` flag: it reflects exactly what was
+     * requested when the options were created, so it round-trips with the choice made there.
+     */
+    public function isDiscoverableRegistration(PublicKeyCredentialCreationOptions $options): bool
+    {
+        return ($options->authenticatorSelection?->residentKey ?? null)
+            === AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED;
     }
 
     /**
@@ -173,16 +193,16 @@ class WebAuthnService
         $validator = $this->buildAttestationValidator();
         $credentialSource = $validator->check($authenticatorResponse, $options, $request, $this->securedRelyingPartyIds);
 
-        // A credential registered while passwordless login is enabled is created with
-        // `residentKey: required` (see createRegistrationOptions), so a successful registration
-        // is necessarily a discoverable credential — a "Passkey". When passwordless login is
-        // disabled the credential is non-discoverable and usable only as a second factor.
+        // Whether this credential is a discoverable "Passkey" is derived from the options it was
+        // registered with (see isDiscoverableRegistration / createRegistrationOptions): a passkey
+        // registration requested a resident key, a 2nd-factor registration did not. This keeps the
+        // stored flag faithful to the per-registration choice rather than the global setting.
         return $this->secondFactorRepository->createSecondFactorForAccount(
             json_encode($credentialSource->jsonSerialize(), JSON_THROW_ON_ERROR),
             $account,
             SecondFactor::TYPE_PUBLIC_KEY,
             $name,
-            $this->passwordlessLoginEnabled
+            $this->isDiscoverableRegistration($options)
         );
     }
 

--- a/Classes/Service/WebAuthnService.php
+++ b/Classes/Service/WebAuthnService.php
@@ -173,11 +173,16 @@ class WebAuthnService
         $validator = $this->buildAttestationValidator();
         $credentialSource = $validator->check($authenticatorResponse, $options, $request, $this->securedRelyingPartyIds);
 
+        // A credential registered while passwordless login is enabled is created with
+        // `residentKey: required` (see createRegistrationOptions), so a successful registration
+        // is necessarily a discoverable credential — a "Passkey". When passwordless login is
+        // disabled the credential is non-discoverable and usable only as a second factor.
         return $this->secondFactorRepository->createSecondFactorForAccount(
             json_encode($credentialSource->jsonSerialize(), JSON_THROW_ON_ERROR),
             $account,
             SecondFactor::TYPE_PUBLIC_KEY,
-            $name
+            $name,
+            $this->passwordlessLoginEnabled
         );
     }
 

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -8,7 +8,19 @@ privilegeTargets:
     'Sandstorm.NeosTwoFactorAuthentication:BackendModule':
       matcher: 'method(Sandstorm\NeosTwoFactorAuthentication\Controller\BackendController->(.*)Action())'
 
+    # Passwordless login must work for not-yet-authenticated users, so it has to be exempt from
+    # the Neos.Neos:AllControllerActions privilege (which requires a backend role). The actions
+    # are still hard-gated at runtime by the `webAuthn.passwordlessLoginEnabled` setting.
+    'Sandstorm.NeosTwoFactorAuthentication:PasswordlessLogin':
+      matcher: 'method(Sandstorm\NeosTwoFactorAuthentication\Controller\PasswordlessLoginController->(options|verify)Action())'
+
 roles:
+  'Neos.Flow:Everybody':
+    privileges:
+      -
+        privilegeTarget: 'Sandstorm.NeosTwoFactorAuthentication:PasswordlessLogin'
+        permission: GRANT
+
   'Neos.Neos:AbstractEditor':
     privileges:
       -

--- a/Configuration/Routes.yaml
+++ b/Configuration/Routes.yaml
@@ -101,3 +101,21 @@
       '@action': 'webAuthnAuthenticateVerify'
       '@format': 'json'
   httpMethods: ['POST']
+
+- name: 'Sandstorm Two Factor Authentication - Passwordless WebAuthn options'
+  uriPattern: 'neos/passwordless-webauthn/options'
+  defaults:
+      '@package': 'Sandstorm.NeosTwoFactorAuthentication'
+      '@controller': 'PasswordlessLogin'
+      '@action': 'options'
+      '@format': 'json'
+  httpMethods: ['POST']
+
+- name: 'Sandstorm Two Factor Authentication - Passwordless WebAuthn verify'
+  uriPattern: 'neos/passwordless-webauthn/verify'
+  defaults:
+      '@package': 'Sandstorm.NeosTwoFactorAuthentication'
+      '@controller': 'PasswordlessLogin'
+      '@action': 'verify'
+      '@format': 'json'
+  httpMethods: ['POST']

--- a/Configuration/Settings.2FA.yaml
+++ b/Configuration/Settings.2FA.yaml
@@ -26,6 +26,12 @@ Sandstorm:
       userVerification: 'discouraged'
       # Browser ceremony timeout in milliseconds.
       timeout: 60000
+      # Opt-in: allow usernameless, passwordless login with a discoverable passkey directly
+      # from the Neos login screen (a user-verified passkey is a full multi-factor login on its
+      # own). OFF by default — must be explicitly enabled. When enabled, new WebAuthn
+      # registrations create discoverable credentials so one passkey serves both passwordless
+      # login and 2nd-factor use.
+      passwordlessLoginEnabled: false
       # Relying-party hostnames for which the server-side library should accept non-HTTPS
       # requests. The browser already treats *.localhost as a secure context (RFC 6761),
       # but the PHP validator only special-cases the literal 'localhost' — list any

--- a/Configuration/Settings.2FA.yaml
+++ b/Configuration/Settings.2FA.yaml
@@ -19,18 +19,21 @@ Sandstorm:
       # Optional override for the relying party identifier. If null, the request's
       # hostname is used (which works for localhost and same-origin production deployments).
       relyingPartyId: null
-      # 'required', 'preferred' or 'discouraged'.
-      # 'discouraged' is the most permissive — works with FIDO U2F-only keys (e.g. YubiKey 4)
-      # via the browser's U2F-compat fallback. Set to 'preferred' or 'required' to demand
-      # PIN/biometric on the authenticator; note that 'required' excludes U2F-only keys.
+      # 'required', 'preferred' or 'discouraged'. Governs the SECOND-FACTOR (non-discoverable)
+      # registration and 2FA authentication path ONLY — passwordless passkey registration always
+      # requires user verification by definition, regardless of this value.
+      # 'discouraged' is the most permissive — works with FIDO U2F-only keys (e.g. YubiKey 4) and
+      # no-PIN security keys via touch only. Set to 'preferred' or 'required' to demand
+      # PIN/biometric on the authenticator; note that 'required' excludes touch-only / U2F-only keys.
       userVerification: 'discouraged'
       # Browser ceremony timeout in milliseconds.
       timeout: 60000
       # Opt-in: allow usernameless, passwordless login with a discoverable passkey directly
       # from the Neos login screen (a user-verified passkey is a full multi-factor login on its
-      # own). OFF by default — must be explicitly enabled. When enabled, new WebAuthn
-      # registrations create discoverable credentials so one passkey serves both passwordless
-      # login and 2nd-factor use.
+      # own). OFF by default — must be explicitly enabled. When enabled, the registration screen
+      # offers a choice: register a discoverable passkey (passwordless-capable, user verification
+      # required) OR a plain touch-only security key as a 2nd factor (user verification per
+      # `userVerification` above). When disabled, only the latter is available.
       passwordlessLoginEnabled: false
       # Relying-party hostnames for which the server-side library should accept non-HTTPS
       # requests. The browser already treats *.localhost as a secure context (RFC 6761),

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -58,3 +58,11 @@ Neos:
                 pattern: 'ControllerObjectName'
                 patternOptions:
                   controllerObjectNamePattern: 'Sandstorm\NeosTwoFactorAuthentication\Controller\(LoginController|BackendController)'
+          # Parallel provider for usernameless passwordless passkey login. It has NO request
+          # pattern, so its token is always active and can be authenticated in-request by the
+          # PasswordlessLoginController; and NO entry point, so the existing Neos.Neos:Backend
+          # WebRedirect still serves the login screen. With Neos' `oneToken` strategy, an
+          # authenticated token here logs the (Neos.Neos:Backend) account into the backend.
+          'Sandstorm.NeosTwoFactorAuthentication:PasswordlessWebAuthn':
+            provider: 'Sandstorm\NeosTwoFactorAuthentication\Security\Authentication\WebAuthnPasswordlessProvider'
+            token: 'Sandstorm\NeosTwoFactorAuthentication\Security\Token\WebAuthnPasswordlessToken'

--- a/Configuration/Views.yaml
+++ b/Configuration/Views.yaml
@@ -4,3 +4,15 @@
   options:
     fusionPathPatterns:
       - 'resource://Sandstorm.NeosTwoFactorAuthentication/Private/Fusion/Login'
+
+# Extend the CORE Neos backend login screen so we can append the passwordless passkey button.
+# Neos' own FusionView for this action loads only 'resource://Neos.Neos/Private/Fusion/Backend',
+# and view configurations are selected by weight (not merged), so this entry must repeat that
+# path AND add our Fusion. Our package loads after Neos.Neos, so this higher-order entry wins.
+-
+  requestFilter: 'isPackage("Neos.Neos") && isController("Login") && isAction("index") && isFormat("html")'
+  viewObjectName: 'Neos\Fusion\View\FusionView'
+  options:
+    fusionPathPatterns:
+      - 'resource://Neos.Neos/Private/Fusion/Backend'
+      - 'resource://Sandstorm.NeosTwoFactorAuthentication/Private/Fusion'

--- a/Migrations/Mysql/Version20260627120000.php
+++ b/Migrations/Mysql/Version20260627120000.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add the `discoverable` flag to second factors so a passwordless-capable "Passkey"
+ * (discoverable/resident credential) can be distinguished from a "Passkey as 2nd factor"
+ * (non-discoverable). Existing rows default to non-discoverable.
+ */
+final class Version20260627120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add discoverable flag to second factor for passkey vs. 2nd-factor distinction';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform,'."
+        );
+
+        $this->addSql('ALTER TABLE sandstorm_neostwofactorauthentication_domain_model_secondfactor ADD discoverable TINYINT(1) DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\MySqlPlatform,
+            "Migration can only be executed safely on '\Doctrine\DBAL\Platforms\MySqlPlatform,'."
+        );
+
+        $this->addSql('ALTER TABLE sandstorm_neostwofactorauthentication_domain_model_secondfactor DROP discoverable');
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,21 +1,30 @@
 # Neos Backend 2FA
 
-Extend the Neos backend login to support second factors. We support TOTP tokens (Authenticator apps)
-and WebAuthn / FIDO2 hardware security keys (e.g. Yubikey).
+Extend the Neos backend login to support second factors and passwordless passkey login. We support
+TOTP tokens (Authenticator apps) and WebAuthn / FIDO2 passkeys — both platform authenticators
+(Touch ID, Windows Hello) and hardware security keys (e.g. Yubikey).
 
 ## What this package does
 
 https://user-images.githubusercontent.com/12086990/153027757-ac715746-0575-4555-bce1-c44603747945.mov
 
 This package allows all users to register their personal second factor — either a TOTP token
-(Authenticator App) or a hardware security key (Yubikey / WebAuthn). Users can register one of each
-and pick which to use at login. As an Administrator you are able to delete factors for users again,
-in case they locked themselves out.
+(Authenticator App) or a **passkey** (WebAuthn / FIDO2: a platform authenticator such as Touch ID or
+Windows Hello, or a hardware key such as a Yubikey). Users can register one of each and pick which to
+use at login. When passwordless login is enabled (see [Passwordless passkey login](#passwordless-passkey-login)),
+a discoverable passkey can also be used to sign in straight from the login screen **without a
+password**. As an Administrator you are able to delete factors for users again, in case they locked
+themselves out.
 
-### Security keys (WebAuthn / FIDO2)
+The management module distinguishes the two kinds of WebAuthn credential by a badge: a discoverable,
+passwordless-capable credential is shown as **"Passkey"**, a non-discoverable one (usable only as a
+second factor, e.g. a U2F-only key) as **"Passkey as 2nd factor"**.
+
+### Passkeys (WebAuthn / FIDO2)
 
 Browsers expose WebAuthn only over `https://` or on `localhost`. Make sure the Neos backend is served
-over HTTPS in production, otherwise the security-key flow will fail.
+over HTTPS in production, otherwise the passkey flow will fail. Note that an IP address (e.g.
+`127.0.0.1`) cannot be used as the relying-party id — use `localhost` for local development.
 
 Configure the relying party identifier when your backend hostname differs from the registered domain:
 
@@ -35,6 +44,34 @@ Sandstorm:
       timeout: 60000
 ```
 
+#### Passwordless passkey login
+
+A discoverable passkey is inherently multi-factor (something you have + the verification you perform
+on the device), so it can serve as the **only** login step. When enabled, a "Sign in with a passkey"
+button appears on the Neos login screen and a single tap signs the user into the backend — no
+username, no password.
+
+This is **disabled by default** and must be turned on explicitly. The gate is enforced server-side
+(the endpoints reject requests while disabled):
+
+```yml
+Sandstorm:
+  NeosTwoFactorAuthentication:
+    webAuthn:
+      # Default false. When true: the login screen shows "Sign in with a passkey", and credentials
+      # registered from then on are created as discoverable (resident) credentials with user
+      # verification required — i.e. real "Passkeys". When false, WebAuthn credentials are
+      # registered as non-discoverable "Passkey as 2nd factor" and the login button is not shown.
+      passwordlessLoginEnabled: true
+```
+
+Notes:
+- A passkey usable for passwordless login must be **discoverable** (resident) and user-verifying.
+  Credentials registered while this setting was off, or on U2F-only keys (e.g. YubiKey 4), are
+  non-discoverable and remain usable only as a second factor.
+- The management module shows a "Register a passkey" banner nudging users who have no discoverable
+  credential yet, so they can opt into faster sign-in.
+
 #### Attestation
 
 There is no setting for attestation. We always request the `none` conveyance preference, so the
@@ -45,11 +82,21 @@ attestation statement types are not supported yet.
 
 #### Authenticator compatibility
 
-| Authenticator                         | `userVerification: discouraged` | `userVerification: required` |
-| ------------------------------------- | ------------------------------- | ---------------------------- |
-| YubiKey 5 / FIDO2 keys                | ✅ touch                        | ✅ PIN + touch               |
-| YubiKey 4 / older U2F-only keys       | ✅ touch (U2F-compat)           | ❌ not supported             |
-| Platform authenticators (Touch ID, Windows Hello) | ✅ biometric              | ✅ biometric                 |
+The first two columns describe registering a credential **as a second factor** (the effect of the
+`userVerification` setting). The last column describes whether the authenticator can be used for
+**passwordless login**, which always requires a discoverable (resident) credential with user
+verification — independent of the `userVerification` setting.
+
+| Authenticator                                     | 2nd factor — `userVerification: discouraged` | 2nd factor — `userVerification: required` | Passwordless passkey         |
+| ------------------------------------------------- | -------------------------------------------- | ----------------------------------------- | ---------------------------- |
+| YubiKey 5 / FIDO2 keys                            | ✅ touch                                      | ✅ PIN + touch                            | ✅ resident key + PIN/touch  |
+| YubiKey 4 / older U2F-only keys                   | ✅ touch (U2F-compat)                         | ❌ not supported                          | ❌ no resident credentials   |
+| Platform authenticators (Touch ID, Windows Hello) | ✅ biometric                                  | ✅ biometric                              | ✅ resident key + biometric  |
+
+> When `passwordlessLoginEnabled` is on, **every** new registration requires a resident key + user
+> verification, so U2F-only keys (e.g. YubiKey 4) can no longer be registered at all while it is
+> enabled — turn it off if you need to enrol such a key as a second factor. Bear in mind that
+> resident credentials also occupy a limited number of slots on hardware keys.
 
 ![Screenshot 2022-02-08 at 17 11 01](https://user-images.githubusercontent.com/12086990/153028043-93e9220e-cc22-4879-9edb-3e156c9accc8.png)
 
@@ -191,11 +238,37 @@ Thx to @Sebobo @Benjamin-K for creating a list of supported and testet apps!
 
     ```
 
+- **Passwordless passkey login** is a separate, opt-in mechanism that does *primary* authentication —
+  the middleware above is only a post-login gate. Because a Flow provider name maps to exactly one
+  token class, we did not try to make the username/password provider also accept a passkey. Instead
+  we added a parallel authentication provider + token (`WebAuthnPasswordlessProvider` /
+  `WebAuthnPasswordlessToken`), registered with **no request pattern** and **no entry point**.
+  - `PasswordlessLoginController` verifies the WebAuthn assertion, resolves the `Neos.Neos:Backend`
+    account from the assertion's user handle (the account's persistence id), sets the parallel token
+    to `AUTHENTICATION_SUCCESSFUL`, calls `securityContext->refreshTokens()` to persist it to the
+    session, and marks the package's 2FA session status `AUTHENTICATED`.
+  - It survives the redirect to `/neos` because `AuthenticationProviderManager` only re-runs
+    providers for tokens that are `AUTHENTICATION_NEEDED`, and the Neos backend uses
+    `authenticationStrategy: oneToken` — so a single authenticated token authenticates the request.
+    `UserService::getCurrentUser()` resolves the Neos user from the *account's party* regardless of
+    which provider authenticated it, so roles and the backend UI work normally.
+  - A user-verified passkey is inherently multi-factor, so the 2FA gate is satisfied in one tap
+    (passwordless login sets the 2FA session status `AUTHENTICATED`, which is check #5 above).
+  - The "Sign in with a passkey" button is injected into the core Neos login screen by overriding
+    `Neos.Neos:Component.Login.Form` (`renderer.@process`) plus a `Views.yaml` entry. The core login
+    is rendered by a plain `FusionView` that does not apply `fusion.autoInclude` and has no script
+    hook, so the (gated) button also emits its own `<script>` to load the ceremony JS. The XHR
+    endpoints are reachable thanks to a `Policy.yaml` grant.
+
 ## When updating Neos, those part will likely crash:
 
 - the login screen for the second factor is a hard copy of the login screen from the `Neos.Neos` package
   - just replaced the username/password form with the form for the second factor
   - maybe has to be replaced when neos gets updated
+- the passwordless "Sign in with a passkey" button is injected into the **core** Neos login screen via
+  a `Views.yaml` override (pointing at `resource://Neos.Neos/Private/Fusion/Backend`) plus a
+  `@process` on `Neos.Neos:Component.Login.Form`. If Neos restructures its login Fusion or view
+  configuration, this injection may need to be re-aligned.
 - hopefully the rest of this package is solid enough to survive the next mayor Neos versions ;)
 
 ## Why not ...?
@@ -264,6 +337,7 @@ make test-neos8-defaults    # default configuration only
 make test-neos8-enforce-all # enforceTwoFactorAuthentication: true
 make test-neos8-enforce-role
 make test-neos8-enforce-provider
+make test-neos8-passwordless # webAuthn.passwordlessLoginEnabled: true
 
 make test-neos9             # same targets for neos9 / PHP 8.5
 
@@ -303,6 +377,7 @@ The `FLOW_CONTEXT` environment variable is passed into the docker compose enviro
 | `@enforce-for-all` | `Production/E2E-SUT/EnforceForAll` | `enforceTwoFactorAuthentication: true` |
 | `@enforce-for-role` | `Production/E2E-SUT/EnforceForRole` | Enforcement scoped to `Neos.Neos:Administrator` |
 | `@enforce-for-provider` | `Production/E2E-SUT/EnforceForProvider` | Enforcement scoped to an authentication provider |
+| `@passwordless` | `Production/E2E-SUT/Passwordless` | `webAuthn.passwordlessLoginEnabled: true` — passwordless passkey login |
 
 #### Test isolation
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ Sandstorm:
       timeout: 60000
 ```
 
+##### Local development over plain HTTP
+
+WebAuthn requires a secure context. The browser treats `localhost` as secure, but the verification
+library is stricter: it only exempts the **exact** host `localhost` from the HTTPS requirement, and
+rejects any other host served over `http://` (including `localhost` subdomains such as
+`myproject.localhost`) with `Invalid scheme. HTTPS required.`.
+
+If your local backend runs over plain HTTP on a host other than `localhost`, list that host under
+`securedRelyingPartyIds` to skip the HTTPS check for it:
+
+```yml
+Sandstorm:
+  NeosTwoFactorAuthentication:
+    webAuthn:
+      # LOCAL DEVELOPMENT ONLY — never add a real production hostname here.
+      # Relying-party ids listed here are treated as secured even without HTTPS.
+      securedRelyingPartyIds:
+        - 'myproject.localhost'
+```
+
+Keep this scoped to a development context (e.g. `Configuration/Development/Settings.yaml`). In
+production the backend must be served over HTTPS and this setting should stay empty (the default).
+
 #### Passwordless passkey login
 
 A discoverable passkey is inherently multi-factor (something you have + the verification you perform

--- a/Resources/Private/Fusion/Integration/Controller/Backend/Index.fusion
+++ b/Resources/Private/Fusion/Integration/Controller/Backend/Index.fusion
@@ -2,34 +2,46 @@ Sandstorm.NeosTwoFactorAuthentication.BackendController.index = Sandstorm.NeosTw
     body = Sandstorm.NeosTwoFactorAuthentication:BodyLayout.Default {
         flashMessages = ${flashMessages}
 
-        # Passkey registration section above the list — only renders when passwordless login is
-        # enabled and the current user has no passkey yet (the component handles that itself).
+        # Section 1: Passkey Registration — shown whenever passwordless login is enabled. Its CTA
+        # goes straight to the single-button passkey screen (discoverable = true).
         headerSection = Sandstorm.NeosTwoFactorAuthentication:Component.RegisterPasskeyBanner {
-            show = ${showRegisterPasskeyBanner}
+            show = ${showPasskeyRegistration}
             registerUri = Neos.Fusion:UriBuilder {
                 package = 'Sandstorm.NeosTwoFactorAuthentication'
                 controller = 'Backend'
                 action = 'newWebAuthn'
+                arguments = Neos.Fusion:DataStructure {
+                    discoverable = true
+                }
             }
         }
 
-        teaserTitle = ${I18n.id('module.index.title').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
+        # teaserTitle intentionally empty; the index renders its own section headings below.
+        teaserTitle = ''
 
-        # The list plus the "Create second factor" action directly below it (previously in the footer).
         content = Neos.Fusion:Component {
             factorsAndPerson = ${factorsAndPerson}
+            # Section 2: Create new second factor — leads to the method picker (TOTP / passkey as 2nd factor).
             createUri = Neos.Fusion:UriBuilder {
                 package = 'Sandstorm.NeosTwoFactorAuthentication'
                 controller = 'Backend'
                 action = 'new'
             }
             renderer = afx`
-                <Sandstorm.NeosTwoFactorAuthentication:Component.SecondFactorList factorsAndPerson={props.factorsAndPerson} />
-                <div class="neos-two-factor__list-actions">
-                    <a href={props.createUri} class="neos-button neos-button-primary">
-                        {I18n.id('module.index.create').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
-                    </a>
-                </div>
+                <section class="neos-two-factor__create-section">
+                    <legend>{I18n.id('module.create.title').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</legend>
+                    <p>{I18n.id('module.create.description').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</p>
+                    <div class="neos-two-factor__list-actions">
+                        <a href={props.createUri} class="neos-button neos-button-primary">
+                            {I18n.id('module.index.create').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
+                        </a>
+                    </div>
+                </section>
+
+                <section class="neos-two-factor__list-section">
+                    <legend>{I18n.id('module.index.title').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</legend>
+                    <Sandstorm.NeosTwoFactorAuthentication:Component.SecondFactorList factorsAndPerson={props.factorsAndPerson} />
+                </section>
             `
         }
     }

--- a/Resources/Private/Fusion/Integration/Controller/Backend/Index.fusion
+++ b/Resources/Private/Fusion/Integration/Controller/Backend/Index.fusion
@@ -2,29 +2,35 @@ Sandstorm.NeosTwoFactorAuthentication.BackendController.index = Sandstorm.NeosTw
     body = Sandstorm.NeosTwoFactorAuthentication:BodyLayout.Default {
         flashMessages = ${flashMessages}
 
-        teaserTitle = ${I18n.id('module.index.title').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
-
-        content = Neos.Fusion:Join {
-            passkeyBanner = Sandstorm.NeosTwoFactorAuthentication:Component.RegisterPasskeyBanner {
-                show = ${showRegisterPasskeyBanner}
-                registerUri = Neos.Fusion:UriBuilder {
-                    package = 'Sandstorm.NeosTwoFactorAuthentication'
-                    controller = 'Backend'
-                    action = 'newWebAuthn'
-                }
-            }
-            list = Sandstorm.NeosTwoFactorAuthentication:Component.SecondFactorList {
-                factorsAndPerson = ${factorsAndPerson}
+        # Passkey registration section above the list — only renders when passwordless login is
+        # enabled and the current user has no passkey yet (the component handles that itself).
+        headerSection = Sandstorm.NeosTwoFactorAuthentication:Component.RegisterPasskeyBanner {
+            show = ${showRegisterPasskeyBanner}
+            registerUri = Neos.Fusion:UriBuilder {
+                package = 'Sandstorm.NeosTwoFactorAuthentication'
+                controller = 'Backend'
+                action = 'newWebAuthn'
             }
         }
 
-        footer = Sandstorm.NeosTwoFactorAuthentication:Component.Footer {
-            title = ${I18n.id('module.index.create').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
-            primaryAction = Neos.Fusion:UriBuilder {
+        teaserTitle = ${I18n.id('module.index.title').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
+
+        # The list plus the "Create second factor" action directly below it (previously in the footer).
+        content = Neos.Fusion:Component {
+            factorsAndPerson = ${factorsAndPerson}
+            createUri = Neos.Fusion:UriBuilder {
                 package = 'Sandstorm.NeosTwoFactorAuthentication'
                 controller = 'Backend'
                 action = 'new'
             }
+            renderer = afx`
+                <Sandstorm.NeosTwoFactorAuthentication:Component.SecondFactorList factorsAndPerson={props.factorsAndPerson} />
+                <div class="neos-two-factor__list-actions">
+                    <a href={props.createUri} class="neos-button neos-button-primary">
+                        {I18n.id('module.index.create').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
+                    </a>
+                </div>
+            `
         }
     }
 }

--- a/Resources/Private/Fusion/Integration/Controller/Backend/Index.fusion
+++ b/Resources/Private/Fusion/Integration/Controller/Backend/Index.fusion
@@ -4,8 +4,18 @@ Sandstorm.NeosTwoFactorAuthentication.BackendController.index = Sandstorm.NeosTw
 
         teaserTitle = ${I18n.id('module.index.title').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
 
-        content = Sandstorm.NeosTwoFactorAuthentication:Component.SecondFactorList {
-            factorsAndPerson = ${factorsAndPerson}
+        content = Neos.Fusion:Join {
+            passkeyBanner = Sandstorm.NeosTwoFactorAuthentication:Component.RegisterPasskeyBanner {
+                show = ${showRegisterPasskeyBanner}
+                registerUri = Neos.Fusion:UriBuilder {
+                    package = 'Sandstorm.NeosTwoFactorAuthentication'
+                    controller = 'Backend'
+                    action = 'newWebAuthn'
+                }
+            }
+            list = Sandstorm.NeosTwoFactorAuthentication:Component.SecondFactorList {
+                factorsAndPerson = ${factorsAndPerson}
+            }
         }
 
         footer = Sandstorm.NeosTwoFactorAuthentication:Component.Footer {

--- a/Resources/Private/Fusion/Integration/Controller/Backend/NewTotp.fusion
+++ b/Resources/Private/Fusion/Integration/Controller/Backend/NewTotp.fusion
@@ -16,6 +16,15 @@ Sandstorm.NeosTwoFactorAuthentication.BackendController.newTotp = Sandstorm.Neos
                         <span class="neos-two-factor__step__number">1</span>
                         <span class="neos-two-factor__step__label">{I18n.id('form.step.setup').package('Sandstorm.NeosTwoFactorAuthentication')}</span>
                     </div>
+                    <div class="neos-control-group">
+                        <Neos.Fusion.Form:Input
+                            field.name="name"
+                            attributes.id="name"
+                            attributes.autocomplete="off"
+                            attributes.placeholder={I18n.id('name-placeholder').package('Sandstorm.NeosTwoFactorAuthentication')}
+                            attributes.aria-label={I18n.id('name-placeholder').package('Sandstorm.NeosTwoFactorAuthentication')}
+                        />
+                    </div>
                     <div class="neos-two-factor__setup-options">
                         <div class="neos-two-factor__setup-option">
                             <p class="neos-two-factor__setup-option__label">
@@ -108,15 +117,6 @@ Sandstorm.NeosTwoFactorAuthentication.BackendController.newTotp = Sandstorm.Neos
                             attributes.placeholder={I18n.id('otp-placeholder').package('Sandstorm.NeosTwoFactorAuthentication')}
                             attributes.aria-label={I18n.id('otp-placeholder').package('Sandstorm.NeosTwoFactorAuthentication')}
                             attributes.autocomplete="off"
-                            attributes.class="neos-span6"
-                        />
-                        <Neos.Fusion.Form:Input
-                            field.name="name"
-                            attributes.id="name"
-                            attributes.autocomplete="off"
-                            attributes.class="neos-span6"
-                            attributes.placeholder={I18n.id('name-placeholder').package('Sandstorm.NeosTwoFactorAuthentication')}
-                            attributes.aria-label={I18n.id('name-placeholder').package('Sandstorm.NeosTwoFactorAuthentication')}
                         />
                     </div>
 

--- a/Resources/Private/Fusion/Integration/Controller/Backend/NewWebAuthn.fusion
+++ b/Resources/Private/Fusion/Integration/Controller/Backend/NewWebAuthn.fusion
@@ -2,9 +2,12 @@ Sandstorm.NeosTwoFactorAuthentication.BackendController.newWebAuthn = Sandstorm.
     body = Sandstorm.NeosTwoFactorAuthentication:BodyLayout.Default {
         flashMessages = ${flashMessages}
 
-        teaserTitle = ${I18n.id('module.newWebAuthn.title').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
+        teaserTitle = ${discoverable
+            ? I18n.id('module.newWebAuthn.title').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()
+            : I18n.id('module.newWebAuthn.titleSecondFactor').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
 
         content = Neos.Fusion:Component {
+            discoverable = ${discoverable}
             redirectUrl = Neos.Fusion:UriBuilder {
                 package = 'Sandstorm.NeosTwoFactorAuthentication'
                 controller = 'Backend'
@@ -17,6 +20,7 @@ Sandstorm.NeosTwoFactorAuthentication.BackendController.newWebAuthn = Sandstorm.
                 <Sandstorm.NeosTwoFactorAuthentication:Component.SetupWebAuthnStep
                     flashMessages={flashMessages}
                     redirectUrl={props.redirectUrl}
+                    discoverable={props.discoverable}
                 />
             `
         }

--- a/Resources/Private/Fusion/Integration/Controller/Login/SetupSecondFactor.fusion
+++ b/Resources/Private/Fusion/Integration/Controller/Login/SetupSecondFactor.fusion
@@ -4,11 +4,34 @@ Sandstorm.NeosTwoFactorAuthentication.LoginController.setupSecondFactor = Sandst
     scripts = ${scripts}
     username = ${username}
     flashMessages = ${flashMessages}
+    notice = ${I18n.id('setup.enforced.notice').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
 
     body = Sandstorm.NeosTwoFactorAuthentication:Component.MethodPicker {
         items = Neos.Fusion:DataStructure {
+            # Passwordless passkey (discoverable, usernameless) — only offered when the feature is
+            # enabled. Registering here satisfies the enforced 2FA gate AND makes the account
+            # passwordless-login capable. Links to the WebAuthn setup screen with discoverable=true.
+            passkey = Neos.Fusion:DataStructure {
+                @if.passwordlessEnabled = ${Configuration.setting('Sandstorm.NeosTwoFactorAuthentication.webAuthn.passwordlessLoginEnabled')}
+                id = 'method.passkey'
+                heading = ${I18n.id('method.passkey.heading').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+                label = ${I18n.id('method.passkey.label').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+                description = ${I18n.id('method.passkey.description').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+                href = Neos.Fusion:UriBuilder {
+                    package = 'Sandstorm.NeosTwoFactorAuthentication'
+                    controller = 'Login'
+                    action = 'setupWebAuthn'
+                    arguments = Neos.Fusion:DataStructure {
+                        discoverable = true
+                    }
+                }
+            }
             totp = Neos.Fusion:DataStructure {
+                # Render the "or" divider before this item only when the passkey option sits above it,
+                # separating the passwordless passkey (option 1) from the second-factor methods (2 + 3).
+                separatorBefore = ${Configuration.setting('Sandstorm.NeosTwoFactorAuthentication.webAuthn.passwordlessLoginEnabled')}
                 id = 'method.totp'
+                heading = ${I18n.id('method.totp.heading').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
                 label = ${I18n.id('method.totp.label').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
                 description = ${I18n.id('method.totp.description').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
                 href = Neos.Fusion:UriBuilder {
@@ -19,6 +42,7 @@ Sandstorm.NeosTwoFactorAuthentication.LoginController.setupSecondFactor = Sandst
             }
             webauthn = Neos.Fusion:DataStructure {
                 id = 'method.webauthn'
+                heading = ${I18n.id('method.webauthn.heading').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
                 label = ${I18n.id('method.webauthn.label').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
                 description = ${I18n.id('method.webauthn.description').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
                 href = Neos.Fusion:UriBuilder {

--- a/Resources/Private/Fusion/Integration/Controller/Login/SetupWebAuthn.fusion
+++ b/Resources/Private/Fusion/Integration/Controller/Login/SetupWebAuthn.fusion
@@ -8,5 +8,6 @@ Sandstorm.NeosTwoFactorAuthentication.LoginController.setupWebAuthn = Sandstorm.
     body = Sandstorm.NeosTwoFactorAuthentication:Component.SetupWebAuthnStep {
         flashMessages = ${flashMessages}
         redirectUrl = ${redirectUrl}
+        discoverable = ${discoverable}
     }
 }

--- a/Resources/Private/Fusion/Integration/Override/LoginForm.fusion
+++ b/Resources/Private/Fusion/Integration/Override/LoginForm.fusion
@@ -1,0 +1,10 @@
+# Append the passwordless passkey button to the core Neos backend login form.
+# Uses Neos.Fusion:Join (not afx interpolation) so the already-rendered form HTML is
+# concatenated verbatim instead of being HTML-escaped. The button component renders nothing
+# unless passwordless login is enabled, so when the feature is off the login screen is unchanged.
+prototype(Neos.Neos:Component.Login.Form) {
+    renderer.@process.appendPasswordlessPasskey = Neos.Fusion:Join {
+        loginForm = ${value}
+        passwordlessButton = Sandstorm.NeosTwoFactorAuthentication:Component.PasswordlessLoginButton
+    }
+}

--- a/Resources/Private/Fusion/Presentation/BodyLayout/Default.fusion
+++ b/Resources/Private/Fusion/Presentation/BodyLayout/Default.fusion
@@ -3,6 +3,10 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:BodyLayout.Default) < prototype(
     teaserTitle = ''
     teaserText = ''
 
+    # Optional section rendered above the teaser title (e.g. the passkey registration nudge on the
+    # index page). Empty by default, so other pages are unchanged.
+    headerSection = ''
+
     flashMessages = ${[]}
 
     footer = ''
@@ -10,6 +14,9 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:BodyLayout.Default) < prototype(
     renderer = afx`
         <main>
             <Sandstorm.NeosTwoFactorAuthentication:Component.FlashMessages flashMessages={props.flashMessages}/>
+
+            {props.headerSection}
+
             <legend>{props.teaserTitle}</legend>
 
             <p>
@@ -19,7 +26,7 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:BodyLayout.Default) < prototype(
             {props.content}
         </main>
 
-        <footer>
+        <footer @if={props.footer}>
             {props.footer}
         </footer>
     `

--- a/Resources/Private/Fusion/Presentation/BodyLayout/Default.fusion
+++ b/Resources/Private/Fusion/Presentation/BodyLayout/Default.fusion
@@ -17,9 +17,9 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:BodyLayout.Default) < prototype(
 
             {props.headerSection}
 
-            <legend>{props.teaserTitle}</legend>
+            <legend @if={props.teaserTitle}>{props.teaserTitle}</legend>
 
-            <p>
+            <p @if={props.teaserText}>
                 {props.teaserText}
             </p>
 

--- a/Resources/Private/Fusion/Presentation/Components/MethodPicker.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/MethodPicker.fusion
@@ -7,7 +7,11 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.MethodPicker) < protot
     renderer = afx`
         <div class="neos-two-factor__method-picker neos-actions">
             <Neos.Fusion:Loop items={props.items} itemName="item">
+                <div @if.separatorBefore={item.separatorBefore} class="neos-two-factor__or-separator">
+                    <span>{I18n.id('login.or').package('Sandstorm.NeosTwoFactorAuthentication')}</span>
+                </div>
                 <div class="neos-two-factor__method-picker__row">
+                    <h2 @if.heading={item.heading} class="neos-two-factor__method-picker__heading">{item.heading}</h2>
                     <a aria-describedby={item.id} href={item.href} class="btn neos-button neos-login-btn neos-two-factor__method-picker__button">
                         {item.label}
                     </a>

--- a/Resources/Private/Fusion/Presentation/Components/PasswordlessLoginButton.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/PasswordlessLoginButton.fusion
@@ -1,0 +1,53 @@
+prototype(Sandstorm.NeosTwoFactorAuthentication:Component.PasswordlessLoginButton) < prototype(Neos.Fusion:Component) {
+    # Server-side gate: render nothing unless passwordless login is explicitly enabled.
+    # This is what keeps the button off the login screen by default (and is the server-side
+    # half of the protection — the endpoints themselves also reject when disabled).
+    enabled = ${Configuration.setting('Sandstorm.NeosTwoFactorAuthentication.webAuthn.passwordlessLoginEnabled')}
+
+    # The core Neos login screen has no script-injection hook, so the (gated) button loads the
+    # WebAuthn ceremony script itself. Only emitted when enabled, so the default login is untouched.
+    scriptUri = Neos.Fusion:ResourceUri {
+        path = 'resource://Sandstorm.NeosTwoFactorAuthentication/Public/JavaScript/webauthn.js'
+    }
+
+    # Localized error strings handed to webauthn.js. Keys match the DOMException name thrown
+    # by the browser; "result" / "default" / "unsupported" are the fixed fallbacks.
+    errorMessages = Neos.Fusion:DataStructure {
+        result = ${I18n.id('webauthn.login.error.result').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+        default = ${I18n.id('webauthn.login.error.generic').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+        unsupported = ${I18n.id('webauthn.error.unsupportedBrowser').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+        NotAllowedError = ${I18n.id('webauthn.error.notAllowed').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+        InvalidStateError = ${I18n.id('webauthn.error.invalidState').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+        NotSupportedError = ${I18n.id('webauthn.error.notSupported').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+        SecurityError = ${I18n.id('webauthn.error.security').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+        AbortError = ${I18n.id('webauthn.error.abort').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+        ConstraintError = ${I18n.id('webauthn.error.constraint').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+        UnknownError = ${I18n.id('webauthn.error.unknown').package('Sandstorm.NeosTwoFactorAuthentication').translate()}
+    }
+
+    renderer = afx`
+        <Neos.Fusion:Fragment @if={props.enabled}>
+            <div
+                class="neos-two-factor__webauthn-step neos-two-factor__passwordless"
+                data-webauthn-passwordless
+                data-options-url="/neos/passwordless-webauthn/options"
+                data-verify-url="/neos/passwordless-webauthn/verify"
+                data-webauthn-messages={Json.stringify(props.errorMessages)}
+            >
+                <div class="neos-actions">
+                    <button type="button"
+                        class="neos-button neos-two-factor__webauthn-button neos-two-factor__passwordless-button"
+                        data-webauthn-trigger
+                    >
+                        {I18n.id('passwordless.login.button').value('Sign in with a passkey').package('Sandstorm.NeosTwoFactorAuthentication')}
+                    </button>
+                </div>
+                <div class="neos-tooltip neos-bottom neos-in neos-tooltip-error" data-webauthn-error style="display: none">
+                    <div class="neos-tooltip-arrow"></div>
+                    <div class="neos-tooltip-inner" role="alert" data-webauthn-error-message></div>
+                </div>
+            </div>
+            <script src={props.scriptUri}></script>
+        </Neos.Fusion:Fragment>
+    `
+}

--- a/Resources/Private/Fusion/Presentation/Components/PasswordlessLoginButton.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/PasswordlessLoginButton.fusion
@@ -10,6 +10,12 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.PasswordlessLoginButto
         path = 'resource://Sandstorm.NeosTwoFactorAuthentication/Public/JavaScript/webauthn.js'
     }
 
+    # The core login screen does not load the package's Login.css either, so the (gated) button
+    # links its own small stylesheet for the full-width button + "or" divider.
+    stylesheetUri = Neos.Fusion:ResourceUri {
+        path = 'resource://Sandstorm.NeosTwoFactorAuthentication/Public/Styles/PasswordlessLoginButton.css'
+    }
+
     # Localized error strings handed to webauthn.js. Keys match the DOMException name thrown
     # by the browser; "result" / "default" / "unsupported" are the fixed fallbacks.
     errorMessages = Neos.Fusion:DataStructure {
@@ -27,6 +33,7 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.PasswordlessLoginButto
 
     renderer = afx`
         <Neos.Fusion:Fragment @if={props.enabled}>
+            <link rel="stylesheet" href={props.stylesheetUri} />
             <div
                 class="neos-two-factor__webauthn-step neos-two-factor__passwordless"
                 data-webauthn-passwordless
@@ -34,6 +41,9 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.PasswordlessLoginButto
                 data-verify-url="/neos/passwordless-webauthn/verify"
                 data-webauthn-messages={Json.stringify(props.errorMessages)}
             >
+                <div class="neos-two-factor__passwordless-or">
+                    {I18n.id('login.or').value('or').package('Sandstorm.NeosTwoFactorAuthentication')}
+                </div>
                 <div class="neos-actions">
                     <button type="button"
                         class="neos-button neos-two-factor__webauthn-button neos-two-factor__passwordless-button"

--- a/Resources/Private/Fusion/Presentation/Components/RegisterPasskeyBanner.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/RegisterPasskeyBanner.fusion
@@ -7,11 +7,9 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.RegisterPasskeyBanner)
     registerUri = ''
 
     renderer = afx`
-        <div @if={props.show} class="neos-two-factor__passkey-banner" data-test-id="register-passkey-banner">
-            <div class="neos-two-factor__passkey-banner-text">
-                <strong>{I18n.id('module.index.passkeyBanner.title').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</strong>
-                <p>{I18n.id('module.index.passkeyBanner.text').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</p>
-            </div>
+        <div @if={props.show} class="neos-two-factor__passkey-registration" data-test-id="register-passkey-banner">
+            <legend>{I18n.id('module.index.passkeyBanner.title').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</legend>
+            <p>{I18n.id('module.index.passkeyBanner.text').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</p>
             <a href={props.registerUri} class="neos-button neos-button-primary" data-test-id="register-passkey-cta">
                 {I18n.id('module.index.passkeyBanner.cta').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
             </a>

--- a/Resources/Private/Fusion/Presentation/Components/RegisterPasskeyBanner.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/RegisterPasskeyBanner.fusion
@@ -1,12 +1,10 @@
 prototype(Sandstorm.NeosTwoFactorAuthentication:Component.RegisterPasskeyBanner) < prototype(Neos.Fusion:Component) {
+    # No @propTypes here on purpose: the other components in this package (Footer, SecondFactorList)
+    # don't declare them, and the globally-enabled AtomicFusion PropTypes validator would otherwise
+    # reject a null `show` (e.g. before the controller assignment is picked up). The defaults below
+    # keep this safe.
     show = false
     registerUri = ''
-
-    @propTypes {
-        @strict = true
-        show = ${PropTypes.bool}
-        registerUri = ${PropTypes.string}
-    }
 
     renderer = afx`
         <div @if={props.show} class="neos-two-factor__passkey-banner" data-test-id="register-passkey-banner">

--- a/Resources/Private/Fusion/Presentation/Components/RegisterPasskeyBanner.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/RegisterPasskeyBanner.fusion
@@ -1,0 +1,22 @@
+prototype(Sandstorm.NeosTwoFactorAuthentication:Component.RegisterPasskeyBanner) < prototype(Neos.Fusion:Component) {
+    show = false
+    registerUri = ''
+
+    @propTypes {
+        @strict = true
+        show = ${PropTypes.bool}
+        registerUri = ${PropTypes.string}
+    }
+
+    renderer = afx`
+        <div @if={props.show} class="neos-two-factor__passkey-banner" data-test-id="register-passkey-banner">
+            <div class="neos-two-factor__passkey-banner-text">
+                <strong>{I18n.id('module.index.passkeyBanner.title').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</strong>
+                <p>{I18n.id('module.index.passkeyBanner.text').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</p>
+            </div>
+            <a href={props.registerUri} class="neos-button neos-button-primary" data-test-id="register-passkey-cta">
+                {I18n.id('module.index.passkeyBanner.cta').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
+            </a>
+        </div>
+    `
+}

--- a/Resources/Private/Fusion/Presentation/Components/RegisterPasskeyBanner.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/RegisterPasskeyBanner.fusion
@@ -7,12 +7,12 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.RegisterPasskeyBanner)
     registerUri = ''
 
     renderer = afx`
-        <div @if={props.show} class="neos-two-factor__passkey-registration" data-test-id="register-passkey-banner">
+        <section @if={props.show} class="neos-two-factor__passkey-registration" data-test-id="register-passkey-banner">
             <legend>{I18n.id('module.index.passkeyBanner.title').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</legend>
             <p>{I18n.id('module.index.passkeyBanner.text').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}</p>
             <a href={props.registerUri} class="neos-button neos-button-primary" data-test-id="register-passkey-cta">
                 {I18n.id('module.index.passkeyBanner.cta').package('Sandstorm.NeosTwoFactorAuthentication').source('Backend').translate()}
             </a>
-        </div>
+        </section>
     `
 }

--- a/Resources/Private/Fusion/Presentation/Components/SecondFactorList.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/SecondFactorList.fusion
@@ -43,7 +43,11 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.SecondFactorList.Entry
     renderer = afx`
         <tr>
             <td>{props.factorAndPerson.user.name.fullName} ({props.factorAndPerson.secondFactor.account.accountIdentifier})</td>
-            <td>{props.factorAndPerson.secondFactor.typeAsName}</td>
+            <td>
+                <span class={'neos-two-factor__badge ' + (props.factorAndPerson.secondFactor.discoverable ? 'neos-two-factor__badge--passkey' : 'neos-two-factor__badge--second-factor')}>
+                    {props.factorAndPerson.secondFactor.typeAsName}
+                </span>
+            </td>
             <td>{props.factorAndPerson.secondFactor.name == null ? '-' : props.factorAndPerson.secondFactor.name}</td>
             <td>{props.factorAndPerson.secondFactor.creationDate == null ? '-' : Date.format(props.factorAndPerson.secondFactor.creationDate, 'Y-m-d H:i')}</td>
             <td>

--- a/Resources/Private/Fusion/Presentation/Components/SetupTotpStep.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/SetupTotpStep.fusion
@@ -72,18 +72,18 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.SetupTotpStep) < proto
             <fieldset>
                 <div class="neos-2fa-control-group neos-actions">
                     <Neos.Fusion.Form:Input
+                        field.name="name"
+                        attributes.id="name"
+                        attributes.placeholder={I18n.id('name-placeholder').package('Sandstorm.NeosTwoFactorAuthentication')}
+                        attributes.aria-label={I18n.id('name-placeholder').package('Sandstorm.NeosTwoFactorAuthentication')}
+                        attributes.autocomplete="off"
+                    />
+                    <Neos.Fusion.Form:Input
                         field.name="secondFactorFromApp"
                         attributes.required="required"
                         attributes.id="secondFactorFromApp"
                         attributes.placeholder={I18n.id('otp-placeholder').package('Sandstorm.NeosTwoFactorAuthentication')}
                         attributes.aria-label={I18n.id('otp-placeholder').package('Sandstorm.NeosTwoFactorAuthentication')}
-                        attributes.autocomplete="off"
-                    />
-                    <Neos.Fusion.Form:Input
-                        field.name="name"
-                        attributes.id="name"
-                        attributes.placeholder={I18n.id('name-placeholder').package('Sandstorm.NeosTwoFactorAuthentication')}
-                        attributes.aria-label={I18n.id('name-placeholder').package('Sandstorm.NeosTwoFactorAuthentication')}
                         attributes.autocomplete="off"
                     />
                     <Neos.Fusion.Form:Button attributes.class="neos-span5 neos-pull-right neos-button neos-login-btn">

--- a/Resources/Private/Fusion/Presentation/Components/SetupWebAuthnStep.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/SetupWebAuthnStep.fusion
@@ -3,6 +3,12 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.SetupWebAuthnStep) < p
     # where to redirect on successful registration
     redirectUrl = '/neos'
 
+    # When passwordless login is enabled the user may register either a passwordless passkey
+    # (discoverable, user-verified) or a plain touch-only security key as a 2nd factor, so we
+    # offer two buttons. When disabled there is only the single 2nd-factor button.
+    # Same source as PasswordlessLoginButton.fusion.
+    passwordlessLoginEnabled = ${Configuration.setting('Sandstorm.NeosTwoFactorAuthentication.webAuthn.passwordlessLoginEnabled')}
+
     # Localized error strings handed to webauthn.js. Keys match the
     # DOMException name thrown by the browser; "result" / "default" /
     # "unsupported" are the fixed fallbacks the script always needs.
@@ -44,7 +50,24 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.SetupWebAuthnStep) < p
                     />
                 </div>
                 <div class="neos-actions">
-                    <button type="button"
+                    <Neos.Fusion:Fragment @if={props.passwordlessLoginEnabled}>
+                        <button type="button"
+                            class="neos-button neos-login-btn neos-two-factor__webauthn-button"
+                            data-webauthn-trigger
+                            data-webauthn-discoverable="true"
+                        >
+                            {I18n.id('webauthn.setup.button.passkey').package('Sandstorm.NeosTwoFactorAuthentication')}
+                        </button>
+                        <button type="button"
+                            class="neos-button neos-two-factor__webauthn-button"
+                            data-webauthn-trigger
+                            data-webauthn-discoverable="false"
+                        >
+                            {I18n.id('webauthn.setup.button.secondFactor').package('Sandstorm.NeosTwoFactorAuthentication')}
+                        </button>
+                    </Neos.Fusion:Fragment>
+                    <button @if={!props.passwordlessLoginEnabled}
+                        type="button"
                         class="neos-button neos-login-btn neos-two-factor__webauthn-button"
                         data-webauthn-trigger
                     >

--- a/Resources/Private/Fusion/Presentation/Components/SetupWebAuthnStep.fusion
+++ b/Resources/Private/Fusion/Presentation/Components/SetupWebAuthnStep.fusion
@@ -3,11 +3,11 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.SetupWebAuthnStep) < p
     # where to redirect on successful registration
     redirectUrl = '/neos'
 
-    # When passwordless login is enabled the user may register either a passwordless passkey
-    # (discoverable, user-verified) or a plain touch-only security key as a 2nd factor, so we
-    # offer two buttons. When disabled there is only the single 2nd-factor button.
-    # Same source as PasswordlessLoginButton.fusion.
-    passwordlessLoginEnabled = ${Configuration.setting('Sandstorm.NeosTwoFactorAuthentication.webAuthn.passwordlessLoginEnabled')}
+    # Whether this screen registers a discoverable, passwordless-capable passkey (true) or a plain
+    # second factor (false). The credential type is decided by the entry point that led here — the
+    # "Passkey Registration" section passes true, the "Create second factor" picker passes false —
+    # so this screen always shows a single button.
+    discoverable = false
 
     # Localized error strings handed to webauthn.js. Keys match the
     # DOMException name thrown by the browser; "result" / "default" /
@@ -50,28 +50,14 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Component.SetupWebAuthnStep) < p
                     />
                 </div>
                 <div class="neos-actions">
-                    <Neos.Fusion:Fragment @if={props.passwordlessLoginEnabled}>
-                        <button type="button"
-                            class="neos-button neos-login-btn neos-two-factor__webauthn-button"
-                            data-webauthn-trigger
-                            data-webauthn-discoverable="true"
-                        >
-                            {I18n.id('webauthn.setup.button.passkey').package('Sandstorm.NeosTwoFactorAuthentication')}
-                        </button>
-                        <button type="button"
-                            class="neos-button neos-two-factor__webauthn-button"
-                            data-webauthn-trigger
-                            data-webauthn-discoverable="false"
-                        >
-                            {I18n.id('webauthn.setup.button.secondFactor').package('Sandstorm.NeosTwoFactorAuthentication')}
-                        </button>
-                    </Neos.Fusion:Fragment>
-                    <button @if={!props.passwordlessLoginEnabled}
-                        type="button"
+                    <button type="button"
                         class="neos-button neos-login-btn neos-two-factor__webauthn-button"
                         data-webauthn-trigger
+                        data-webauthn-discoverable={props.discoverable ? 'true' : 'false'}
                     >
-                        {I18n.id('webauthn.setup.button').package('Sandstorm.NeosTwoFactorAuthentication')}
+                        {props.discoverable
+                            ? I18n.id('webauthn.setup.button.passkey').package('Sandstorm.NeosTwoFactorAuthentication')
+                            : I18n.id('webauthn.setup.button.secondFactor').package('Sandstorm.NeosTwoFactorAuthentication')}
                     </button>
                 </div>
                 <div class="neos-tooltip neos-bottom neos-in neos-tooltip-error" data-webauthn-error style="display: none">

--- a/Resources/Private/Fusion/Presentation/Pages/SetupSecondFactorPage.fusion
+++ b/Resources/Private/Fusion/Presentation/Pages/SetupSecondFactorPage.fusion
@@ -4,6 +4,9 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Page.SetupSecondFactorPage) < pr
     scripts = ${[]}
     username = ''
     flashMessages = ${[]}
+    # Optional prominent notice shown directly below the login heading. Set by the enforced
+    # method-picker page to explain why 2FA setup is required; empty on the method sub-pages.
+    notice = ''
     # rendered inside the .neos-login-body container — pass a Fusion component instance
     body = ''
 
@@ -76,6 +79,8 @@ prototype(Sandstorm.NeosTwoFactorAuthentication:Page.SetupSecondFactorPage) < pr
                                 <h1 class="neos-login-heading">
                                     {I18n.id('login.index.title').value('Login to').package('Neos.Neos').source('Main')} <strong>{props.site.name}</strong>
                                 </h1>
+
+                                <p @if.set={props.notice} class="neos-two-factor__enforced-notice" role="note">{props.notice}</p>
 
                                 <div class="neos-login-body neos neos-two-factor__login">
                                     <Sandstorm.NeosTwoFactorAuthentication:Component.LoginFlashMessages flashMessages={props.flashMessages} />

--- a/Resources/Private/Translations/de/Backend.xlf
+++ b/Resources/Private/Translations/de/Backend.xlf
@@ -16,12 +16,12 @@
         <target>Liste aller registrierten zweiten Faktoren</target>
       </trans-unit>
       <trans-unit id="module.index.passkeyBanner.title" xml:space="preserve">
-        <source>Set up a passkey for faster sign-in</source>
-        <target>Richten Sie einen Passkey für die schnellere Anmeldung ein</target>
+        <source>Passkey Registration</source>
+        <target>Passkey-Registrierung</target>
       </trans-unit>
       <trans-unit id="module.index.passkeyBanner.text" xml:space="preserve">
-        <source>Register a passkey to sign in without a password — one tap with your fingerprint, face, or device PIN.</source>
-        <target>Registrieren Sie einen Passkey, um sich ohne Passwort anzumelden — mit Fingerabdruck, Gesicht oder Geräte-PIN.</target>
+        <source>Set up a passkey for faster sign-in without a password.</source>
+        <target>Richten Sie einen Passkey für die schnellere Anmeldung ohne Passwort ein.</target>
       </trans-unit>
       <trans-unit id="module.index.passkeyBanner.cta" xml:space="preserve">
         <source>Register a passkey</source>

--- a/Resources/Private/Translations/de/Backend.xlf
+++ b/Resources/Private/Translations/de/Backend.xlf
@@ -15,6 +15,18 @@
         <source>List of all registered second factors</source>
         <target>Liste aller registrierten zweiten Faktoren</target>
       </trans-unit>
+      <trans-unit id="module.index.passkeyBanner.title" xml:space="preserve">
+        <source>Set up a passkey for faster sign-in</source>
+        <target>Richten Sie einen Passkey für die schnellere Anmeldung ein</target>
+      </trans-unit>
+      <trans-unit id="module.index.passkeyBanner.text" xml:space="preserve">
+        <source>Register a passkey to sign in without a password — one tap with your fingerprint, face, or device PIN.</source>
+        <target>Registrieren Sie einen Passkey, um sich ohne Passwort anzumelden — mit Fingerabdruck, Gesicht oder Geräte-PIN.</target>
+      </trans-unit>
+      <trans-unit id="module.index.passkeyBanner.cta" xml:space="preserve">
+        <source>Register a passkey</source>
+        <target>Passkey registrieren</target>
+      </trans-unit>
       <trans-unit id="module.index.list.header.username" xml:space="preserve">
         <source>User</source>
         <target>Nutzer</target>
@@ -102,8 +114,8 @@
         <target>Wählen Sie, welchen zweiten Faktor Sie einrichten möchten:</target>
       </trans-unit>
       <trans-unit id="module.newWebAuthn.title" xml:space="preserve">
-        <source>Register a security key</source>
-        <target>Sicherheitsschlüssel registrieren</target>
+        <source>Register a passkey</source>
+        <target>Passkey registrieren</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Translations/de/Backend.xlf
+++ b/Resources/Private/Translations/de/Backend.xlf
@@ -51,6 +51,14 @@
         <source>Create second factor</source>
         <target>Zweiten Faktor erstellen</target>
       </trans-unit>
+      <trans-unit id="module.create.title" xml:space="preserve">
+        <source>Create new second factor</source>
+        <target>Neuen zweiten Faktor erstellen</target>
+      </trans-unit>
+      <trans-unit id="module.create.description" xml:space="preserve">
+        <source>Setup a new second factor to secure your Neos account.</source>
+        <target>Richten Sie einen neuen zweiten Faktor ein, um Ihr Neos-Konto zu schützen.</target>
+      </trans-unit>
 
       <trans-unit id="module.index.delete.header" xml:space="preserve">
         <source>Do you really want to delete the second factor?</source>
@@ -116,6 +124,10 @@
       <trans-unit id="module.newWebAuthn.title" xml:space="preserve">
         <source>Register a passkey</source>
         <target>Passkey registrieren</target>
+      </trans-unit>
+      <trans-unit id="module.newWebAuthn.titleSecondFactor" xml:space="preserve">
+        <source>Register a security key as second factor</source>
+        <target>Sicherheitsschlüssel als zweiten Faktor registrieren</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -110,6 +110,10 @@
         <source>Use security key</source>
         <target>Sicherheitsschlüssel verwenden</target>
       </trans-unit>
+      <trans-unit id="passwordless.login.button" xml:space="preserve">
+        <source>Sign in with a passkey</source>
+        <target>Mit einem Passkey anmelden</target>
+      </trans-unit>
       <trans-unit id="login.or" xml:space="preserve">
         <source>or</source>
         <target>oder</target>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -75,12 +75,12 @@
         <target>Verwenden Sie Google Authenticator, Authy, 1Password oder eine andere TOTP-kompatible App.</target>
       </trans-unit>
       <trans-unit id="method.webauthn.label" xml:space="preserve">
-        <source>Passkey</source>
-        <target>Passkey</target>
+        <source>Passkey as second factor</source>
+        <target>Passkey als zweiter Faktor</target>
       </trans-unit>
       <trans-unit id="method.webauthn.description" xml:space="preserve">
-        <source>Use a passkey stored on your phone or computer, or a hardware security key such as a Yubikey.</source>
-        <target>Verwenden Sie einen Passkey auf Ihrem Smartphone oder Computer oder einen Hardware-Sicherheitsschlüssel wie einen Yubikey.</target>
+        <source>Use a passkey or a hardware security key (e.g. a YubiKey) as a second factor — a touch is enough, no PIN required.</source>
+        <target>Verwenden Sie einen Passkey oder einen Hardware-Sicherheitsschlüssel (z. B. einen YubiKey) als zweiten Faktor – eine Berührung genügt, keine PIN erforderlich.</target>
       </trans-unit>
       <trans-unit id="webauthn.setup.intro" xml:space="preserve">
         <source>Press the button below to create a passkey. When prompted, confirm with your fingerprint, face, device PIN, or hardware key.</source>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -82,6 +82,30 @@
         <source>Use a passkey or a hardware security key (e.g. a YubiKey) as a second factor — a touch is enough, no PIN required.</source>
         <target>Verwenden Sie einen Passkey oder einen Hardware-Sicherheitsschlüssel (z. B. einen YubiKey) als zweiten Faktor – eine Berührung genügt, keine PIN erforderlich.</target>
       </trans-unit>
+      <trans-unit id="method.passkey.label" xml:space="preserve">
+        <source>Register a passkey</source>
+        <target>Passkey einrichten</target>
+      </trans-unit>
+      <trans-unit id="method.passkey.description" xml:space="preserve">
+        <source>Set up a passkey for faster sign-in without a password.</source>
+        <target>Richten Sie einen Passkey für die schnellere Anmeldung ohne Passwort ein.</target>
+      </trans-unit>
+      <trans-unit id="method.passkey.heading" xml:space="preserve">
+        <source>Passkey</source>
+        <target>Passkey</target>
+      </trans-unit>
+      <trans-unit id="method.totp.heading" xml:space="preserve">
+        <source>One-Time-Password 2FA</source>
+        <target>Einmalpasswort-2FA</target>
+      </trans-unit>
+      <trans-unit id="method.webauthn.heading" xml:space="preserve">
+        <source>Passkey 2FA</source>
+        <target>Passkey-2FA</target>
+      </trans-unit>
+      <trans-unit id="setup.enforced.notice" xml:space="preserve">
+        <source>Your security settings requires Two Factor Authentication to be enabled. Choose one of the options below now. Further authentication methods can be configured once logged in.</source>
+        <target>Ihre Sicherheitseinstellungen erfordern die Aktivierung der Zwei-Faktor-Authentifizierung. Wählen Sie jetzt eine der folgenden Optionen. Weitere Authentifizierungsmethoden können nach der Anmeldung konfiguriert werden.</target>
+      </trans-unit>
       <trans-unit id="webauthn.setup.intro" xml:space="preserve">
         <source>Press the button below to create a passkey. When prompted, confirm with your fingerprint, face, device PIN, or hardware key.</source>
         <target>Drücken Sie unten auf die Schaltfläche, um einen Passkey zu erstellen. Bestätigen Sie bei Aufforderung mit Fingerabdruck, Gesicht, Geräte-PIN oder Hardwareschlüssel.</target>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -103,8 +103,8 @@
         <target>Passkey-2FA</target>
       </trans-unit>
       <trans-unit id="setup.enforced.notice" xml:space="preserve">
-        <source>Your security settings requires Two Factor Authentication to be enabled. Choose one of the options below now. Further authentication methods can be configured once logged in.</source>
-        <target>Ihre Sicherheitseinstellungen erfordern die Aktivierung der Zwei-Faktor-Authentifizierung. Wählen Sie jetzt eine der folgenden Optionen. Weitere Authentifizierungsmethoden können nach der Anmeldung konfiguriert werden.</target>
+        <source>Your security settings require Two Factor Authentication to be enabled. Choose one of the options below now. Further authentication methods can be configured in the Two-Factor Authentication Backend Module.</source>
+        <target>Ihre Sicherheitseinstellungen erfordern die Aktivierung der Zwei-Faktor-Authentifizierung. Wählen Sie jetzt eine der folgenden Optionen. Weitere Authentifizierungsmethoden können im Zwei-Faktor-Authentifizierungsmenü konfiguriert werden.</target>
       </trans-unit>
       <trans-unit id="webauthn.setup.intro" xml:space="preserve">
         <source>Press the button below to create a passkey. When prompted, confirm with your fingerprint, face, device PIN, or hardware key.</source>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -90,6 +90,14 @@
         <source>Register passkey</source>
         <target>Passkey registrieren</target>
       </trans-unit>
+      <trans-unit id="webauthn.setup.button.passkey" xml:space="preserve">
+        <source>Register passkey</source>
+        <target>Passkey registrieren</target>
+      </trans-unit>
+      <trans-unit id="webauthn.setup.button.secondFactor" xml:space="preserve">
+        <source>Register security key as 2nd factor</source>
+        <target>Sicherheitsschlüssel als 2. Faktor registrieren</target>
+      </trans-unit>
       <trans-unit id="webauthn.setup.success" xml:space="preserve">
         <source>Passkey registered successfully.</source>
         <target>Passkey erfolgreich registriert.</target>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -75,40 +75,40 @@
         <target>Verwenden Sie Google Authenticator, Authy, 1Password oder eine andere TOTP-kompatible App.</target>
       </trans-unit>
       <trans-unit id="method.webauthn.label" xml:space="preserve">
-        <source>Security key (Yubikey / WebAuthn)</source>
-        <target>Sicherheitsschlüssel (Yubikey / WebAuthn)</target>
+        <source>Passkey</source>
+        <target>Passkey</target>
       </trans-unit>
       <trans-unit id="method.webauthn.description" xml:space="preserve">
-        <source>Use a hardware security key such as a Yubikey, or another FIDO2 authenticator.</source>
-        <target>Verwenden Sie einen Hardware-Sicherheitsschlüssel wie einen Yubikey oder einen anderen FIDO2-Authenticator.</target>
+        <source>Use a passkey stored on your phone or computer, or a hardware security key such as a Yubikey.</source>
+        <target>Verwenden Sie einen Passkey auf Ihrem Smartphone oder Computer oder einen Hardware-Sicherheitsschlüssel wie einen Yubikey.</target>
       </trans-unit>
       <trans-unit id="webauthn.setup.intro" xml:space="preserve">
-        <source>Plug in your security key and press the button below. When prompted, tap your key and enter its PIN if requested.</source>
-        <target>Stecken Sie Ihren Sicherheitsschlüssel ein und drücken Sie unten auf die Schaltfläche. Tippen Sie bei Aufforderung auf den Schlüssel und geben Sie ggf. die PIN ein.</target>
+        <source>Press the button below to create a passkey. When prompted, confirm with your fingerprint, face, device PIN, or hardware key.</source>
+        <target>Drücken Sie unten auf die Schaltfläche, um einen Passkey zu erstellen. Bestätigen Sie bei Aufforderung mit Fingerabdruck, Gesicht, Geräte-PIN oder Hardwareschlüssel.</target>
       </trans-unit>
       <trans-unit id="webauthn.setup.button" xml:space="preserve">
-        <source>Register security key</source>
-        <target>Sicherheitsschlüssel registrieren</target>
+        <source>Register passkey</source>
+        <target>Passkey registrieren</target>
       </trans-unit>
       <trans-unit id="webauthn.setup.success" xml:space="preserve">
-        <source>Security key registered successfully.</source>
-        <target>Sicherheitsschlüssel erfolgreich registriert.</target>
+        <source>Passkey registered successfully.</source>
+        <target>Passkey erfolgreich registriert.</target>
       </trans-unit>
       <trans-unit id="webauthn.setup.error.unsupported" xml:space="preserve">
-        <source>Your browser does not support security keys.</source>
-        <target>Ihr Browser unterstützt keine Sicherheitsschlüssel.</target>
+        <source>Your browser does not support passkeys.</source>
+        <target>Ihr Browser unterstützt keine Passkeys.</target>
       </trans-unit>
       <trans-unit id="webauthn.setup.error.generic" xml:space="preserve">
-        <source>Could not register security key. Please try again.</source>
-        <target>Der Sicherheitsschlüssel konnte nicht registriert werden. Bitte versuchen Sie es erneut.</target>
+        <source>Could not register passkey. Please try again.</source>
+        <target>Der Passkey konnte nicht registriert werden. Bitte versuchen Sie es erneut.</target>
       </trans-unit>
       <trans-unit id="webauthn.login.prompt" xml:space="preserve">
-        <source>Touch your security key to continue.</source>
-        <target>Berühren Sie Ihren Sicherheitsschlüssel, um fortzufahren.</target>
+        <source>Use your passkey to continue.</source>
+        <target>Verwenden Sie Ihren Passkey, um fortzufahren.</target>
       </trans-unit>
       <trans-unit id="webauthn.login.button" xml:space="preserve">
-        <source>Use security key</source>
-        <target>Sicherheitsschlüssel verwenden</target>
+        <source>Use passkey</source>
+        <target>Passkey verwenden</target>
       </trans-unit>
       <trans-unit id="passwordless.login.button" xml:space="preserve">
         <source>Sign in with a passkey</source>
@@ -123,48 +123,48 @@
         <target>Abbrechen und zurück zur Anmeldung</target>
       </trans-unit>
       <trans-unit id="webauthn.login.error.generic" xml:space="preserve">
-        <source>Could not verify your security key. Please try again.</source>
-        <target>Der Sicherheitsschlüssel konnte nicht überprüft werden. Bitte versuchen Sie es erneut.</target>
+        <source>Could not verify your passkey. Please try again.</source>
+        <target>Der Passkey konnte nicht überprüft werden. Bitte versuchen Sie es erneut.</target>
       </trans-unit>
       <trans-unit id="webauthn.login.error.result" xml:space="preserve">
-        <source>Security key verification failed</source>
-        <target>Verifizierung des Sicherheitsschlüssels fehlgeschlagen</target>
+        <source>Passkey verification failed</source>
+        <target>Verifizierung des Passkeys fehlgeschlagen</target>
       </trans-unit>
       <trans-unit id="webauthn.setup.error.result" xml:space="preserve">
-        <source>Security key registration failed</source>
-        <target>Registrierung des Sicherheitsschlüssels fehlgeschlagen</target>
+        <source>Passkey registration failed</source>
+        <target>Registrierung des Passkeys fehlgeschlagen</target>
       </trans-unit>
       <trans-unit id="webauthn.error.unsupportedBrowser" xml:space="preserve">
-        <source>Your browser or device does not support security keys. Use a supported browser, or choose another login method.</source>
-        <target>Ihr Browser oder Gerät unterstützt keine Sicherheitsschlüssel. Verwenden Sie einen unterstützten Browser oder wählen Sie eine andere Anmeldemethode.</target>
+        <source>Your browser or device does not support passkeys. Use a supported browser, or choose another login method.</source>
+        <target>Ihr Browser oder Gerät unterstützt keine Passkeys. Verwenden Sie einen unterstützten Browser oder wählen Sie eine andere Anmeldemethode.</target>
       </trans-unit>
       <trans-unit id="webauthn.error.notAllowed" xml:space="preserve">
-        <source>The request was cancelled or timed out. Connect your security key and tap it when the browser prompts you, then try again.</source>
-        <target>Die Anfrage wurde abgebrochen oder ist abgelaufen. Verbinden Sie Ihren Sicherheitsschlüssel und berühren Sie ihn, sobald der Browser Sie dazu auffordert, und versuchen Sie es dann erneut.</target>
+        <source>The request was cancelled or timed out. Confirm with your passkey when the browser prompts you, then try again.</source>
+        <target>Die Anfrage wurde abgebrochen oder ist abgelaufen. Bestätigen Sie mit Ihrem Passkey, sobald der Browser Sie dazu auffordert, und versuchen Sie es dann erneut.</target>
       </trans-unit>
       <trans-unit id="webauthn.error.invalidState" xml:space="preserve">
-        <source>This security key is already registered. Use a different key, or sign in with this one instead.</source>
-        <target>Dieser Sicherheitsschlüssel ist bereits registriert. Verwenden Sie einen anderen Schlüssel oder melden Sie sich mit diesem an.</target>
+        <source>This passkey is already registered. Use a different one, or sign in with it instead.</source>
+        <target>Dieser Passkey ist bereits registriert. Verwenden Sie einen anderen oder melden Sie sich mit diesem an.</target>
       </trans-unit>
       <trans-unit id="webauthn.error.notSupported" xml:space="preserve">
-        <source>Your browser or device does not support security keys. Use a supported browser, or choose another login method.</source>
-        <target>Ihr Browser oder Gerät unterstützt keine Sicherheitsschlüssel. Verwenden Sie einen unterstützten Browser oder wählen Sie eine andere Anmeldemethode.</target>
+        <source>Your browser or device does not support passkeys. Use a supported browser, or choose another login method.</source>
+        <target>Ihr Browser oder Gerät unterstützt keine Passkeys. Verwenden Sie einen unterstützten Browser oder wählen Sie eine andere Anmeldemethode.</target>
       </trans-unit>
       <trans-unit id="webauthn.error.security" xml:space="preserve">
-        <source>The page origin is not allowed for security keys. Make sure you are on the correct, secure (https) address.</source>
-        <target>Die Herkunft der Seite ist für Sicherheitsschlüssel nicht zulässig. Stellen Sie sicher, dass Sie sich auf der korrekten, sicheren (https) Adresse befinden.</target>
+        <source>The page origin is not allowed for passkeys. Make sure you are on the correct, secure (https) address.</source>
+        <target>Die Herkunft der Seite ist für Passkeys nicht zulässig. Stellen Sie sicher, dass Sie sich auf der korrekten, sicheren (https) Adresse befinden.</target>
       </trans-unit>
       <trans-unit id="webauthn.error.abort" xml:space="preserve">
         <source>The request was aborted before it could finish. Please try again.</source>
         <target>Die Anfrage wurde abgebrochen, bevor sie abgeschlossen werden konnte. Bitte versuchen Sie es erneut.</target>
       </trans-unit>
       <trans-unit id="webauthn.error.constraint" xml:space="preserve">
-        <source>Your authenticator could not meet the requirements for this login. Try a different security key.</source>
-        <target>Ihr Authentifikator konnte die Anforderungen für diese Anmeldung nicht erfüllen. Verwenden Sie einen anderen Sicherheitsschlüssel.</target>
+        <source>Your authenticator could not meet the requirements for this login. Try a different passkey.</source>
+        <target>Ihr Authentifikator konnte die Anforderungen für diese Anmeldung nicht erfüllen. Verwenden Sie einen anderen Passkey.</target>
       </trans-unit>
       <trans-unit id="webauthn.error.unknown" xml:space="preserve">
-        <source>An unexpected error occurred while communicating with your security key. Please try again.</source>
-        <target>Bei der Kommunikation mit Ihrem Sicherheitsschlüssel ist ein unerwarteter Fehler aufgetreten. Bitte versuchen Sie es erneut.</target>
+        <source>An unexpected error occurred while communicating with your passkey. Please try again.</source>
+        <target>Bei der Kommunikation mit Ihrem Passkey ist ein unerwarteter Fehler aufgetreten. Bitte versuchen Sie es erneut.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Translations/en/Backend.xlf
+++ b/Resources/Private/Translations/en/Backend.xlf
@@ -13,10 +13,10 @@
         <source>List of all registered second factors</source>
       </trans-unit>
       <trans-unit id="module.index.passkeyBanner.title" xml:space="preserve">
-        <source>Set up a passkey for faster sign-in</source>
+        <source>Passkey Registration</source>
       </trans-unit>
       <trans-unit id="module.index.passkeyBanner.text" xml:space="preserve">
-        <source>Register a passkey to sign in without a password — one tap with your fingerprint, face, or device PIN.</source>
+        <source>Set up a passkey for faster sign-in without a password.</source>
       </trans-unit>
       <trans-unit id="module.index.passkeyBanner.cta" xml:space="preserve">
         <source>Register a passkey</source>

--- a/Resources/Private/Translations/en/Backend.xlf
+++ b/Resources/Private/Translations/en/Backend.xlf
@@ -12,6 +12,15 @@
       <trans-unit id="module.index.title" xml:space="preserve">
         <source>List of all registered second factors</source>
       </trans-unit>
+      <trans-unit id="module.index.passkeyBanner.title" xml:space="preserve">
+        <source>Set up a passkey for faster sign-in</source>
+      </trans-unit>
+      <trans-unit id="module.index.passkeyBanner.text" xml:space="preserve">
+        <source>Register a passkey to sign in without a password — one tap with your fingerprint, face, or device PIN.</source>
+      </trans-unit>
+      <trans-unit id="module.index.passkeyBanner.cta" xml:space="preserve">
+        <source>Register a passkey</source>
+      </trans-unit>
       <trans-unit id="module.index.list.header.username" xml:space="preserve">
         <source>User</source>
       </trans-unit>
@@ -78,7 +87,7 @@
         <source>Choose which second factor you would like to set up:</source>
       </trans-unit>
       <trans-unit id="module.newWebAuthn.title" xml:space="preserve">
-        <source>Register a security key</source>
+        <source>Register a passkey</source>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Translations/en/Backend.xlf
+++ b/Resources/Private/Translations/en/Backend.xlf
@@ -39,6 +39,12 @@
       <trans-unit id="module.index.create" xml:space="preserve">
         <source>Create second factor</source>
       </trans-unit>
+      <trans-unit id="module.create.title" xml:space="preserve">
+        <source>Create new second factor</source>
+      </trans-unit>
+      <trans-unit id="module.create.description" xml:space="preserve">
+        <source>Setup a new second factor to secure your Neos account.</source>
+      </trans-unit>
 
       <trans-unit id="module.index.delete.header" xml:space="preserve">
         <source>Do you really want to delete the second factor?</source>
@@ -88,6 +94,9 @@
       </trans-unit>
       <trans-unit id="module.newWebAuthn.title" xml:space="preserve">
         <source>Register a passkey</source>
+      </trans-unit>
+      <trans-unit id="module.newWebAuthn.titleSecondFactor" xml:space="preserve">
+        <source>Register a security key as second factor</source>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -83,6 +83,9 @@
       <trans-unit id="webauthn.login.button" xml:space="preserve">
         <source>Use security key</source>
       </trans-unit>
+      <trans-unit id="passwordless.login.button" xml:space="preserve">
+        <source>Sign in with a passkey</source>
+      </trans-unit>
       <trans-unit id="login.or" xml:space="preserve">
         <source>or</source>
       </trans-unit>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -62,6 +62,24 @@
       <trans-unit id="method.webauthn.description" xml:space="preserve">
         <source>Use a passkey or a hardware security key (e.g. a YubiKey) as a second factor — a touch is enough, no PIN required.</source>
       </trans-unit>
+      <trans-unit id="method.passkey.label" xml:space="preserve">
+        <source>Register a passkey</source>
+      </trans-unit>
+      <trans-unit id="method.passkey.description" xml:space="preserve">
+        <source>Set up a passkey for faster sign-in without a password.</source>
+      </trans-unit>
+      <trans-unit id="method.passkey.heading" xml:space="preserve">
+        <source>Passkey</source>
+      </trans-unit>
+      <trans-unit id="method.totp.heading" xml:space="preserve">
+        <source>One-Time-Password 2FA</source>
+      </trans-unit>
+      <trans-unit id="method.webauthn.heading" xml:space="preserve">
+        <source>Passkey 2FA</source>
+      </trans-unit>
+      <trans-unit id="setup.enforced.notice" xml:space="preserve">
+        <source>Your security settings requires Two Factor Authentication to be enabled. Choose one of the options below now. Further authentication methods can be configured once logged in.</source>
+      </trans-unit>
       <trans-unit id="webauthn.setup.intro" xml:space="preserve">
         <source>Press the button below to create a passkey. When prompted, confirm with your fingerprint, face, device PIN, or hardware key.</source>
       </trans-unit>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -78,7 +78,7 @@
         <source>Passkey 2FA</source>
       </trans-unit>
       <trans-unit id="setup.enforced.notice" xml:space="preserve">
-        <source>Your security settings requires Two Factor Authentication to be enabled. Choose one of the options below now. Further authentication methods can be configured once logged in.</source>
+        <source>Your security settings require Two Factor Authentication to be enabled. Choose one of the options below now. Further authentication methods can be configured in the Two-Factor Authentication Backend Module.</source>
       </trans-unit>
       <trans-unit id="webauthn.setup.intro" xml:space="preserve">
         <source>Press the button below to create a passkey. When prompted, confirm with your fingerprint, face, device PIN, or hardware key.</source>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -68,6 +68,12 @@
       <trans-unit id="webauthn.setup.button" xml:space="preserve">
         <source>Register passkey</source>
       </trans-unit>
+      <trans-unit id="webauthn.setup.button.passkey" xml:space="preserve">
+        <source>Register passkey</source>
+      </trans-unit>
+      <trans-unit id="webauthn.setup.button.secondFactor" xml:space="preserve">
+        <source>Register security key as 2nd factor</source>
+      </trans-unit>
       <trans-unit id="webauthn.setup.success" xml:space="preserve">
         <source>Passkey registered successfully.</source>
       </trans-unit>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -57,31 +57,31 @@
         <source>Use Google Authenticator, Authy, 1Password or any TOTP-compatible app on your phone.</source>
       </trans-unit>
       <trans-unit id="method.webauthn.label" xml:space="preserve">
-        <source>Security key (Yubikey / WebAuthn)</source>
+        <source>Passkey</source>
       </trans-unit>
       <trans-unit id="method.webauthn.description" xml:space="preserve">
-        <source>Use a hardware security key such as a Yubikey, or another FIDO2 authenticator.</source>
+        <source>Use a passkey stored on your phone or computer, or a hardware security key such as a Yubikey.</source>
       </trans-unit>
       <trans-unit id="webauthn.setup.intro" xml:space="preserve">
-        <source>Plug in your security key and press the button below. When prompted, tap your key and enter its PIN if requested.</source>
+        <source>Press the button below to create a passkey. When prompted, confirm with your fingerprint, face, device PIN, or hardware key.</source>
       </trans-unit>
       <trans-unit id="webauthn.setup.button" xml:space="preserve">
-        <source>Register security key</source>
+        <source>Register passkey</source>
       </trans-unit>
       <trans-unit id="webauthn.setup.success" xml:space="preserve">
-        <source>Security key registered successfully.</source>
+        <source>Passkey registered successfully.</source>
       </trans-unit>
       <trans-unit id="webauthn.setup.error.unsupported" xml:space="preserve">
-        <source>Your browser does not support security keys.</source>
+        <source>Your browser does not support passkeys.</source>
       </trans-unit>
       <trans-unit id="webauthn.setup.error.generic" xml:space="preserve">
-        <source>Could not register security key. Please try again.</source>
+        <source>Could not register passkey. Please try again.</source>
       </trans-unit>
       <trans-unit id="webauthn.login.prompt" xml:space="preserve">
-        <source>Touch your security key to continue.</source>
+        <source>Use your passkey to continue.</source>
       </trans-unit>
       <trans-unit id="webauthn.login.button" xml:space="preserve">
-        <source>Use security key</source>
+        <source>Use passkey</source>
       </trans-unit>
       <trans-unit id="passwordless.login.button" xml:space="preserve">
         <source>Sign in with a passkey</source>
@@ -93,37 +93,37 @@
         <source>Cancel and return to login</source>
       </trans-unit>
       <trans-unit id="webauthn.login.error.generic" xml:space="preserve">
-        <source>Could not verify your security key. Please try again.</source>
+        <source>Could not verify your passkey. Please try again.</source>
       </trans-unit>
       <trans-unit id="webauthn.login.error.result" xml:space="preserve">
-        <source>Security key verification failed</source>
+        <source>Passkey verification failed</source>
       </trans-unit>
       <trans-unit id="webauthn.setup.error.result" xml:space="preserve">
-        <source>Security key registration failed</source>
+        <source>Passkey registration failed</source>
       </trans-unit>
       <trans-unit id="webauthn.error.unsupportedBrowser" xml:space="preserve">
-        <source>Your browser or device does not support security keys. Use a supported browser, or choose another login method.</source>
+        <source>Your browser or device does not support passkeys. Use a supported browser, or choose another login method.</source>
       </trans-unit>
       <trans-unit id="webauthn.error.notAllowed" xml:space="preserve">
-        <source>The request was cancelled or timed out. Connect your security key and tap it when the browser prompts you, then try again.</source>
+        <source>The request was cancelled or timed out. Confirm with your passkey when the browser prompts you, then try again.</source>
       </trans-unit>
       <trans-unit id="webauthn.error.invalidState" xml:space="preserve">
-        <source>This security key is already registered. Use a different key, or sign in with this one instead.</source>
+        <source>This passkey is already registered. Use a different one, or sign in with it instead.</source>
       </trans-unit>
       <trans-unit id="webauthn.error.notSupported" xml:space="preserve">
-        <source>Your browser or device does not support security keys. Use a supported browser, or choose another login method.</source>
+        <source>Your browser or device does not support passkeys. Use a supported browser, or choose another login method.</source>
       </trans-unit>
       <trans-unit id="webauthn.error.security" xml:space="preserve">
-        <source>The page origin is not allowed for security keys. Make sure you are on the correct, secure (https) address.</source>
+        <source>The page origin is not allowed for passkeys. Make sure you are on the correct, secure (https) address.</source>
       </trans-unit>
       <trans-unit id="webauthn.error.abort" xml:space="preserve">
         <source>The request was aborted before it could finish. Please try again.</source>
       </trans-unit>
       <trans-unit id="webauthn.error.constraint" xml:space="preserve">
-        <source>Your authenticator could not meet the requirements for this login. Try a different security key.</source>
+        <source>Your authenticator could not meet the requirements for this login. Try a different passkey.</source>
       </trans-unit>
       <trans-unit id="webauthn.error.unknown" xml:space="preserve">
-        <source>An unexpected error occurred while communicating with your security key. Please try again.</source>
+        <source>An unexpected error occurred while communicating with your passkey. Please try again.</source>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -57,10 +57,10 @@
         <source>Use Google Authenticator, Authy, 1Password or any TOTP-compatible app on your phone.</source>
       </trans-unit>
       <trans-unit id="method.webauthn.label" xml:space="preserve">
-        <source>Passkey</source>
+        <source>Passkey as second factor</source>
       </trans-unit>
       <trans-unit id="method.webauthn.description" xml:space="preserve">
-        <source>Use a passkey stored on your phone or computer, or a hardware security key such as a Yubikey.</source>
+        <source>Use a passkey or a hardware security key (e.g. a YubiKey) as a second factor — a touch is enough, no PIN required.</source>
       </trans-unit>
       <trans-unit id="webauthn.setup.intro" xml:space="preserve">
         <source>Press the button below to create a passkey. When prompted, confirm with your fingerprint, face, device PIN, or hardware key.</source>

--- a/Resources/Public/JavaScript/webauthn.js
+++ b/Resources/Public/JavaScript/webauthn.js
@@ -129,12 +129,11 @@
         return true;
     }
 
-    async function runRegistration(container) {
+    async function runRegistration(container, trigger, discoverable) {
         clearError(container);
-        var trigger = container.querySelector('[data-webauthn-trigger]');
         if (trigger) trigger.disabled = true;
         try {
-            var options = await postJson(container.dataset.optionsUrl);
+            var options = await postJson(container.dataset.optionsUrl, { discoverable: discoverable });
             var credential = await navigator.credentials.create({
                 publicKey: decodeCreationOptions(options)
             });
@@ -172,8 +171,14 @@
     function init() {
         document.querySelectorAll('[data-webauthn-register]').forEach(function (container) {
             if (!checkSupport(container)) return;
-            var trigger = container.querySelector('[data-webauthn-trigger]');
-            if (trigger) trigger.addEventListener('click', function () { runRegistration(container); });
+            // There may be more than one trigger (e.g. "Register passkey" vs "Register security
+            // key as 2nd factor"); each carries its own data-webauthn-discoverable flag.
+            container.querySelectorAll('[data-webauthn-trigger]').forEach(function (trigger) {
+                trigger.addEventListener('click', function () {
+                    var discoverable = trigger.dataset.webauthnDiscoverable === 'true';
+                    runRegistration(container, trigger, discoverable);
+                });
+            });
         });
 
         document.querySelectorAll('[data-webauthn-login]').forEach(function (container) {

--- a/Resources/Public/JavaScript/webauthn.js
+++ b/Resources/Public/JavaScript/webauthn.js
@@ -186,6 +186,16 @@
                 setTimeout(function () { runAuthentication(container); }, 200);
             }
         });
+
+        // Passwordless (usernameless) login on the main login screen. The assertion ceremony
+        // is identical to the 2nd-factor login (options -> get -> verify -> redirect), so we
+        // reuse runAuthentication. Click-only (no auto-trigger): the OS passkey prompt must
+        // not pop up on every visit to the login page — the user opts in by clicking.
+        document.querySelectorAll('[data-webauthn-passwordless]').forEach(function (container) {
+            if (!checkSupport(container)) return;
+            var trigger = container.querySelector('[data-webauthn-trigger]');
+            if (trigger) trigger.addEventListener('click', function () { runAuthentication(container); });
+        });
     }
 
     if (document.readyState === 'loading') {

--- a/Resources/Public/Styles/Backend.css
+++ b/Resources/Public/Styles/Backend.css
@@ -88,6 +88,48 @@ img.neos-two-factor__qr-code {
     height: unset !important;
 }
 
+/* Passkey registration section — shown above the list when passwordless login is enabled and the
+   current user has no passkey yet. Styled as a section (its <legend> matches the list heading),
+   with a divider separating it from the list below. Prefixed `.neos div.…` so it beats Neos core's
+   responsive reset (`.neos div, .neos p, … { margin: 0; padding: 0 }`, specificity 0,1,1), which
+   otherwise zeroes the padding/margin — same pattern as the method-picker rule below. */
+.neos div.neos-two-factor__passkey-registration {
+    margin-bottom: 12px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid #3f3f3f;
+}
+
+.neos div.neos-two-factor__passkey-registration p {
+    margin: 0 0 12px;
+    font-size: 13px;
+    opacity: .8;
+}
+
+/* "Create second factor" action, shown directly below the list (moved out of the page footer). */
+.neos div.neos-two-factor__list-actions {
+    margin-top: 16px;
+}
+
+/* Credential type tag in the list: "Passkey" (discoverable, accent) vs "Passkey as 2nd factor". */
+.neos-two-factor__badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 2px;
+    font-size: 12px;
+    line-height: 18px;
+    white-space: nowrap;
+}
+
+.neos-two-factor__badge--passkey {
+    background-color: #00b5ff;
+    color: #fff;
+}
+
+.neos-two-factor__badge--second-factor {
+    background-color: #3f3f3f;
+    color: #fff;
+}
+
 /* Keyboard focus ring for buttons and button-styled links. Backend.css only loads on this
    package's standalone module page, so .neos-button is already package-scoped. !important
    beats Neos core's `:focus { outline: 0 }` reset. */

--- a/Resources/Public/Styles/Backend.css
+++ b/Resources/Public/Styles/Backend.css
@@ -88,18 +88,19 @@ img.neos-two-factor__qr-code {
     height: unset !important;
 }
 
-/* Passkey registration section — shown above the list when passwordless login is enabled and the
-   current user has no passkey yet. Styled as a section (its <legend> matches the list heading),
-   with a divider separating it from the list below. Prefixed `.neos div.…` so it beats Neos core's
-   responsive reset (`.neos div, .neos p, … { margin: 0; padding: 0 }`, specificity 0,1,1), which
-   otherwise zeroes the padding/margin — same pattern as the method-picker rule below. */
-.neos div.neos-two-factor__passkey-registration {
+/* Passkey registration section and "create second factor" section — each gets a bottom divider so
+   the index reads as banner ─── create ─── list. Prefixed `.neos section.…` (specificity 0,2,1) so
+   it beats Neos core's responsive reset (`.neos div, .neos p, … { margin: 0; padding: 0 }`,
+   specificity 0,1,1) regardless of whether core also resets `section` — same pattern as the
+   method-picker rule below. */
+.neos section.neos-two-factor__passkey-registration,
+.neos section.neos-two-factor__create-section {
     margin-bottom: 12px;
     padding-bottom: 24px;
     border-bottom: 1px solid #3f3f3f;
 }
 
-.neos div.neos-two-factor__passkey-registration p {
+.neos section.neos-two-factor__passkey-registration p {
     margin: 0 0 12px;
     font-size: 13px;
     opacity: .8;

--- a/Resources/Public/Styles/Login.css
+++ b/Resources/Public/Styles/Login.css
@@ -29,19 +29,49 @@
     opacity: 0.85;
 }
 
+/* Prominent notice explaining why the enforced 2FA setup is shown, below the login heading. */
+.neos-two-factor__enforced-notice {
+    margin: 0 0 20px;
+    padding: 12px 16px;
+    border-left: 3px solid #00b5ff;
+    background: rgba(0, 181, 255, .5);
+    color: #fff;
+    font-size: .95rem;
+    line-height: 1.5;
+    text-align: left;
+}
+
 /* Method picker — login layout: stacked column, light text on the dark login box.
-   (Backend.css gives the backend module a button-beside-description row layout.) */
+   Each option stacks heading -> description -> button (button below the explanatory text),
+   ordered via `order` so the shared markup's source order stays valid for the backend
+   (Backend.css gives the backend module a button-beside-description row layout). */
 .neos-two-factor__method-picker {
     gap: 16px;
 }
 
 .neos-two-factor__method-picker__row {
     flex-direction: column;
+    align-items: stretch;
     gap: 8px;
+    text-align: left;
+}
+
+.neos-two-factor__method-picker__heading {
+    order: 1;
+    margin: 0;
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 600;
 }
 
 .neos-two-factor__method-picker__description {
+    order: 2;
     color: #fff;
+}
+
+.neos-two-factor__method-picker__button {
+    order: 3;
+    align-self: flex-start;
 }
 
 /* Separator between the two methods on the 2FA challenge screen */

--- a/Resources/Public/Styles/PasswordlessLoginButton.css
+++ b/Resources/Public/Styles/PasswordlessLoginButton.css
@@ -1,0 +1,39 @@
+/*
+ * Styles for the passwordless "Sign in with a passkey" button that is injected into the CORE Neos
+ * login screen. That screen does NOT load the package's Login.css, so this small stylesheet is
+ * linked directly by the Component.PasswordlessLoginButton Fusion prototype. Kept deliberately
+ * minimal to match the existing Neos login look (full-width button + a muted "or" divider).
+ */
+
+[data-webauthn-passwordless] {
+    margin-top: 16px;
+}
+
+/* "or" divider between the password login and the passkey button. Mirrors the separator the
+   package already uses on the 2FA challenge screen. */
+[data-webauthn-passwordless] .neos-two-factor__passwordless-or {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+    color: #fff;
+    opacity: .6;
+    text-transform: uppercase;
+    font-size: .75rem;
+    letter-spacing: .1em;
+}
+
+[data-webauthn-passwordless] .neos-two-factor__passwordless-or::before,
+[data-webauthn-passwordless] .neos-two-factor__passwordless-or::after {
+    content: '';
+    flex: 1;
+    border-top: 1px solid currentColor;
+    opacity: .5;
+}
+
+/* Match the full-width login button. We can't reuse `.neos-login-btn` (the E2E suite selects the
+   password submit by that class), so the width is set explicitly here. */
+[data-webauthn-passwordless] .neos-two-factor__passwordless-button {
+    display: block;
+    width: 100%;
+}

--- a/Tests/E2E/Makefile
+++ b/Tests/E2E/Makefile
@@ -94,6 +94,14 @@ test-neos9-enforce-role:
 test-neos9-enforce-provider:
 	cd $(E2E_DIR) && npm run test:neos9:enforce-provider
 
+## Run neos8 E2E tests for passwordless passkey login
+test-neos8-passwordless:
+	cd $(E2E_DIR) && npm run test:neos8:passwordless
+
+## Run neos9 E2E tests for passwordless passkey login
+test-neos9-passwordless:
+	cd $(E2E_DIR) && npm run test:neos9:passwordless
+
 ## Start the neos8 SUT containers
 start-sut-neos8:
 	docker compose -f $(NEOS8_COMPOSE) up -d --build

--- a/Tests/E2E/Makefile
+++ b/Tests/E2E/Makefile
@@ -6,8 +6,8 @@ NEOS9_COMPOSE = $(E2E_DIR)/system_under_test/neos9/docker-compose.yaml
 
 .SILENT:
 .PHONY: help setup setup-sut setup-test generate-bdd-files test test-neos8 test-neos9 \
-	test-neos8-defaults test-neos8-enforce-all test-neos8-enforce-role test-neos8-enforce-provider test-neos8-passwordless \
-	test-neos9-defaults test-neos9-enforce-all test-neos9-enforce-role test-neos9-enforce-provider test-neos9-passwordless \
+	test-neos8-defaults test-neos8-enforce-all test-neos8-enforce-role test-neos8-enforce-provider test-neos8-passwordless test-neos8-enforce-all-passwordless \
+	test-neos9-defaults test-neos9-enforce-all test-neos9-enforce-role test-neos9-enforce-provider test-neos9-passwordless test-neos9-enforce-all-passwordless \
 	start-sut-neos8 start-sut-neos9 log-sut-neos8 log-sut-neos9 enter-sut-neos8 enter-sut-neos9 sut-down
 
 # COLORS
@@ -57,10 +57,10 @@ generate-bdd-files:
 test: test-neos8 test-neos9
 
 ## Run all neos8 E2E tests
-test-neos8: test-neos8-defaults test-neos8-enforce-all test-neos8-enforce-role test-neos8-enforce-provider test-neos8-passwordless
+test-neos8: test-neos8-defaults test-neos8-enforce-all test-neos8-enforce-role test-neos8-enforce-provider test-neos8-passwordless test-neos8-enforce-all-passwordless
 
 ## Run all neos9 E2E tests
-test-neos9: test-neos9-defaults test-neos9-enforce-all test-neos9-enforce-role test-neos9-enforce-provider test-neos9-passwordless
+test-neos9: test-neos9-defaults test-neos9-enforce-all test-neos9-enforce-role test-neos9-enforce-provider test-neos9-passwordless test-neos9-enforce-all-passwordless
 
 ## Run neos8 E2E tests with default 2FA settings
 test-neos8-defaults:
@@ -98,9 +98,17 @@ test-neos9-enforce-provider:
 test-neos8-passwordless:
 	cd $(E2E_DIR) && npm run test:neos8:passwordless
 
+## Run neos8 E2E tests with 2FA enforced for all users AND passwordless enabled
+test-neos8-enforce-all-passwordless:
+	cd $(E2E_DIR) && npm run test:neos8:enforce-all-passwordless
+
 ## Run neos9 E2E tests for passwordless passkey login
 test-neos9-passwordless:
 	cd $(E2E_DIR) && npm run test:neos9:passwordless
+
+## Run neos9 E2E tests with 2FA enforced for all users AND passwordless enabled
+test-neos9-enforce-all-passwordless:
+	cd $(E2E_DIR) && npm run test:neos9:enforce-all-passwordless
 
 ## Start the neos8 SUT containers
 start-sut-neos8:

--- a/Tests/E2E/Makefile
+++ b/Tests/E2E/Makefile
@@ -6,8 +6,8 @@ NEOS9_COMPOSE = $(E2E_DIR)/system_under_test/neos9/docker-compose.yaml
 
 .SILENT:
 .PHONY: help setup setup-sut setup-test generate-bdd-files test test-neos8 test-neos9 \
-	test-neos8-defaults test-neos8-enforce-all test-neos8-enforce-role test-neos8-enforce-provider \
-	test-neos9-defaults test-neos9-enforce-all test-neos9-enforce-role test-neos9-enforce-provider \
+	test-neos8-defaults test-neos8-enforce-all test-neos8-enforce-role test-neos8-enforce-provider test-neos8-passwordless \
+	test-neos9-defaults test-neos9-enforce-all test-neos9-enforce-role test-neos9-enforce-provider test-neos9-passwordless \
 	start-sut-neos8 start-sut-neos9 log-sut-neos8 log-sut-neos9 enter-sut-neos8 enter-sut-neos9 sut-down
 
 # COLORS
@@ -57,10 +57,10 @@ generate-bdd-files:
 test: test-neos8 test-neos9
 
 ## Run all neos8 E2E tests
-test-neos8: test-neos8-defaults test-neos8-enforce-all test-neos8-enforce-role test-neos8-enforce-provider
+test-neos8: test-neos8-defaults test-neos8-enforce-all test-neos8-enforce-role test-neos8-enforce-provider test-neos8-passwordless
 
 ## Run all neos9 E2E tests
-test-neos9: test-neos9-defaults test-neos9-enforce-all test-neos9-enforce-role test-neos9-enforce-provider
+test-neos9: test-neos9-defaults test-neos9-enforce-all test-neos9-enforce-role test-neos9-enforce-provider test-neos9-passwordless
 
 ## Run neos8 E2E tests with default 2FA settings
 test-neos8-defaults:

--- a/Tests/E2E/features/default/backend-module.feature
+++ b/Tests/E2E/features/default/backend-module.feature
@@ -18,7 +18,7 @@ Feature: Backend module for two-factor authentication management with default se
     And I navigate to the 2FA management page
     And I add a new WebAuthn 2FA device with name "Admin Security Key"
     Then There should be 1 enrolled 2FA device
-    And There should be 1 enrolled "Security Key" 2FA device
+    And There should be 1 enrolled "Passkey as 2nd factor" 2FA device
     And There should be a 2FA device with the name "Admin Security Key"
 
   Scenario: Admin user can have both a TOTP and a WebAuthn 2FA device
@@ -29,7 +29,7 @@ Feature: Backend module for two-factor authentication management with default se
     And I add a new WebAuthn 2FA device with name "Admin Security Key"
     Then There should be 2 enrolled 2FA devices
     And There should be 1 enrolled "OTP code" 2FA device
-    And There should be 1 enrolled "Security Key" 2FA device
+    And There should be 1 enrolled "Passkey as 2nd factor" 2FA device
     And There should be a 2FA device with the name "Admin Test Device"
     And There should be a 2FA device with the name "Admin Security Key"
 

--- a/Tests/E2E/features/default/passwordless-disabled.feature
+++ b/Tests/E2E/features/default/passwordless-disabled.feature
@@ -1,0 +1,12 @@
+@default-context
+Feature: Passwordless login is disabled by default
+
+  Passwordless passkey login is opt-in. With the default configuration it must be impossible:
+  the login screen shows no passkey button, and the endpoint refuses to authenticate anyone.
+
+  Scenario: The passkey sign-in button is not shown when passwordless login is disabled
+    When I open the login page
+    Then I should not see the passkey sign-in button
+
+  Scenario: The passwordless verify endpoint is forbidden when passwordless login is disabled
+    Then the passwordless verify endpoint is forbidden

--- a/Tests/E2E/features/enforce-for-all-passwordless/login.feature
+++ b/Tests/E2E/features/enforce-for-all-passwordless/login.feature
@@ -1,0 +1,37 @@
+@enforce-for-all-passwordless
+Feature: Enforced 2FA setup with passwordless passkey registration
+
+  When 2FA is enforced for all users AND passwordless login is enabled, a factor-less
+  user forced to set up a second factor can enrol a discoverable, usernameless passkey
+  right at the enforced-setup gate — and then sign in passwordlessly with it afterwards.
+
+  Background:
+    Given A user with username "admin", password "password" and role "Neos.Neos:Administrator" exists
+    And A user with username "editor", password "password" and role "Neos.Neos:Editor" exists
+
+  Scenario: The enforced-setup screen offers passwordless passkey registration
+    When I log in with username "editor" and password "password"
+    Then I should see the 2FA setup page
+    And I should see the "Register a passkey" 2FA method option
+
+  Scenario: A passkey registered during enforced setup enables passwordless login
+    Given I have a virtual security key
+    When I log in with username "editor" and password "password"
+    And I set up a passwordless passkey during enforced setup
+    Then I should see the Neos content page
+    When I log out
+    And I sign in with a passkey
+    Then I should see the Neos content page
+
+  Scenario: A separator divides the passwordless passkey option from the second-factor methods
+    When I log in with username "editor" and password "password"
+    Then I should see the 2FA setup page
+    And I should see a separator between the passkey option and the other 2FA methods
+
+  Scenario: The enforced-setup screen explains the requirement and labels each option
+    When I log in with username "editor" and password "password"
+    Then I should see the 2FA setup page
+    And I should see the enforced 2FA setup notice
+    And I should see a 2FA section heading "Passkey"
+    And I should see a 2FA section heading "One-Time-Password 2FA"
+    And I should see a 2FA section heading "Passkey 2FA"

--- a/Tests/E2E/features/enforce-for-all/login.feature
+++ b/Tests/E2E/features/enforce-for-all/login.feature
@@ -42,5 +42,5 @@ Feature: Login flow with 2FA enforced for all users
     When I log in with username "editor" and password "password"
     And I set up a WebAuthn 2FA device with name "Editor Security Key"
     And I navigate to the 2FA management page
-    Then There should be 1 enrolled "Security Key" 2FA device
+    Then There should be 1 enrolled "Passkey as 2nd factor" 2FA device
     And There should be a 2FA device with the name "Editor Security Key"

--- a/Tests/E2E/features/enforce-for-all/login.feature
+++ b/Tests/E2E/features/enforce-for-all/login.feature
@@ -20,6 +20,11 @@ Feature: Login flow with 2FA enforced for all users
     Then I should see the 2FA setup page
     And I should see the 2FA method selection
 
+  Scenario: Passwordless passkey registration is not offered when the feature is off
+    When I log in with username "editor" and password "password"
+    Then I should see the 2FA setup page
+    And I should not see the "Register a passkey" 2FA method option
+
   Scenario: User can cancel the enforced 2FA setup and return to the login screen
     When I log in with username "editor" and password "password"
     And I should see the 2FA setup page

--- a/Tests/E2E/features/passwordless/login.feature
+++ b/Tests/E2E/features/passwordless/login.feature
@@ -1,0 +1,18 @@
+@passwordless
+Feature: Passwordless passkey login
+
+  When passwordless login is enabled, a user who has registered a (discoverable)
+  passkey can sign in with a single tap on the login screen — no username, no
+  password — and lands straight in the Neos backend.
+
+  Background:
+    Given A user with username "admin", password "password" and role "Neos.Neos:Administrator" exists
+
+  Scenario: User can log in passwordlessly with a registered passkey
+    Given I have a virtual security key
+    When I log in with username "admin" and password "password"
+    And I navigate to the 2FA management page
+    And I add a new WebAuthn 2FA device
+    And I log out
+    And I sign in with a passkey
+    Then I should see the Neos content page

--- a/Tests/E2E/features/passwordless/login.feature
+++ b/Tests/E2E/features/passwordless/login.feature
@@ -16,3 +16,39 @@ Feature: Passwordless passkey login
     And I log out
     And I sign in with a passkey
     Then I should see the Neos content page
+
+  Scenario: A credential registered while passwordless login is enabled is labelled "Passkey"
+    Given I have a virtual security key
+    When I log in with username "admin" and password "password"
+    And I navigate to the 2FA management page
+    And I add a new WebAuthn 2FA device with name "Admin Passkey"
+    Then There should be 1 enrolled "Passkey" 2FA device
+    And There should be a 2FA device with the name "Admin Passkey"
+
+  Scenario: The management module nudges users without a passkey to register one
+    Given I have a virtual security key
+    When I log in with username "admin" and password "password"
+    And I navigate to the 2FA management page
+    Then I should see the register-a-passkey banner
+    When I register a passkey from the banner
+    Then There should be 1 enrolled "Passkey" 2FA device
+    And I should not see the register-a-passkey banner
+
+  Scenario: User lands on the originally requested page after a passwordless login
+    Given I have a virtual security key
+    When I log in with username "admin" and password "password"
+    And I navigate to the 2FA management page
+    And I add a new WebAuthn 2FA device
+    And I log out
+    And I open "/neos/management/twoFactorAuthentication" while logged out
+    And I sign in with a passkey
+    Then I should land on "/neos/management/twoFactorAuthentication"
+
+  Scenario: Cancelling the passkey sign-in keeps the user on the login screen
+    Given I have a virtual security key
+    When I log in with username "admin" and password "password"
+    And I navigate to the 2FA management page
+    And I add a new WebAuthn 2FA device
+    And I log out
+    And I start a passkey sign-in but cancel it
+    Then I should see the login page

--- a/Tests/E2E/features/passwordless/login.feature
+++ b/Tests/E2E/features/passwordless/login.feature
@@ -52,3 +52,12 @@ Feature: Passwordless passkey login
     And I log out
     And I start a passkey sign-in but cancel it
     Then I should see the login page
+
+  # Regression: starting a passwordless ceremony seeds `webAuthnPasswordlessOptions` into the
+  # session (without an authentication status). Abandoning it and then logging in normally used
+  # to crash the SecondFactorMiddleware with a 500 (getAuthenticationStatus returning null).
+  Scenario: Abandoning a passwordless ceremony does not break a later password login
+    Given I have a virtual security key
+    And I start a passkey sign-in but cancel it
+    When I log in with username "admin" and password "password"
+    Then I should see the Neos content page

--- a/Tests/E2E/features/passwordless/login.feature
+++ b/Tests/E2E/features/passwordless/login.feature
@@ -12,7 +12,7 @@ Feature: Passwordless passkey login
     Given I have a virtual security key
     When I log in with username "admin" and password "password"
     And I navigate to the 2FA management page
-    And I add a new WebAuthn 2FA device
+    And I register a passkey
     And I log out
     And I sign in with a passkey
     Then I should see the Neos content page
@@ -21,24 +21,24 @@ Feature: Passwordless passkey login
     Given I have a virtual security key
     When I log in with username "admin" and password "password"
     And I navigate to the 2FA management page
-    And I add a new WebAuthn 2FA device with name "Admin Passkey"
+    And I register a passkey with name "Admin Passkey"
     Then There should be 1 enrolled "Passkey" 2FA device
     And There should be a 2FA device with the name "Admin Passkey"
 
-  Scenario: The management module nudges users without a passkey to register one
+  Scenario: The Passkey Registration section stays available so more passkeys can be added
     Given I have a virtual security key
     When I log in with username "admin" and password "password"
     And I navigate to the 2FA management page
     Then I should see the register-a-passkey banner
     When I register a passkey from the banner
     Then There should be 1 enrolled "Passkey" 2FA device
-    And I should not see the register-a-passkey banner
+    And I should see the register-a-passkey banner
 
   Scenario: User lands on the originally requested page after a passwordless login
     Given I have a virtual security key
     When I log in with username "admin" and password "password"
     And I navigate to the 2FA management page
-    And I add a new WebAuthn 2FA device
+    And I register a passkey
     And I log out
     And I open "/neos/management/twoFactorAuthentication" while logged out
     And I sign in with a passkey
@@ -48,7 +48,7 @@ Feature: Passwordless passkey login
     Given I have a virtual security key
     When I log in with username "admin" and password "password"
     And I navigate to the 2FA management page
-    And I add a new WebAuthn 2FA device
+    And I register a passkey
     And I log out
     And I start a passkey sign-in but cancel it
     Then I should see the login page

--- a/Tests/E2E/features/passwordless/second-factor.feature
+++ b/Tests/E2E/features/passwordless/second-factor.feature
@@ -10,6 +10,13 @@ Feature: Touch-only security key as a 2nd factor while passwordless login is ena
   Background:
     Given A user with username "admin", password "password" and role "Neos.Neos:Administrator" exists
 
+  Scenario: The management index is split into passkey, create-second-factor and list sections
+    When I log in with username "admin" and password "password"
+    And I navigate to the 2FA management page
+    Then I should see a section titled "Passkey Registration"
+    And I should see a section titled "Create new second factor"
+    And I should see a section titled "List of all registered second factors"
+
   Scenario: A touch-only security key registers as a 2nd factor, not a passkey
     Given I have a touch-only virtual security key
     When I log in with username "admin" and password "password"

--- a/Tests/E2E/features/passwordless/second-factor.feature
+++ b/Tests/E2E/features/passwordless/second-factor.feature
@@ -1,0 +1,30 @@
+@passwordless
+Feature: Touch-only security key as a 2nd factor while passwordless login is enabled
+
+  Even with passwordless login enabled, a user may register a touch-only security key
+  (no FIDO2 PIN, so it can prove presence but not user verification) as a plain second
+  factor instead of a discoverable passkey. This previously failed at registration with
+  "User authentication required." because every registration was forced to require user
+  verification.
+
+  Background:
+    Given A user with username "admin", password "password" and role "Neos.Neos:Administrator" exists
+
+  Scenario: A touch-only security key registers as a 2nd factor, not a passkey
+    Given I have a touch-only virtual security key
+    When I log in with username "admin" and password "password"
+    And I navigate to the 2FA management page
+    And I add a new WebAuthn 2nd-factor device with name "Admin Touch Key"
+    Then There should be 1 enrolled 2FA device
+    And There should be 1 enrolled "Passkey as 2nd factor" 2FA device
+    And There should be a 2FA device with the name "Admin Touch Key"
+
+  Scenario: A touch-only 2nd-factor security key satisfies the 2FA gate at login
+    Given I have a touch-only virtual security key
+    When I log in with username "admin" and password "password"
+    And I navigate to the 2FA management page
+    And I add a new WebAuthn 2nd-factor device with name "Admin Touch Key"
+    And I log out
+    And I log in with username "admin" and password "password"
+    And I authenticate with my security key
+    Then I should see the Neos content page

--- a/Tests/E2E/global-teardown.ts
+++ b/Tests/E2E/global-teardown.ts
@@ -2,6 +2,12 @@ import { execSync } from 'node:child_process';
 import { dirname } from 'node:path';
 
 export default async function globalTeardown() {
+  // KEEP_SUT=1 leaves the SUT running so the next run reuses it (see reuseExistingServer
+  // in playwright.config.ts) instead of paying the multi-minute cold-boot every time.
+  // Useful for a tight local dev loop; CI leaves it unset so the environment is torn down.
+  if (process.env.KEEP_SUT) {
+    return;
+  }
   const sut = process.env.SUT || 'neos8';
   execSync(
     `docker compose -f ./system_under_test/${sut}/docker-compose.yaml down -v`,

--- a/Tests/E2E/helpers/2fa-pages.ts
+++ b/Tests/E2E/helpers/2fa-pages.ts
@@ -8,7 +8,7 @@ import { generateOtp } from './totp.js';
  */
 const METHOD_LINK_NAME = {
   totp: 'Authenticator app',
-  webauthn: 'Security key (Yubikey / WebAuthn)',
+  webauthn: 'Passkey',
 } as const;
 
 /**
@@ -229,6 +229,24 @@ export class BackendModulePage {
     await this.page.locator('.neos-table').waitFor();
   }
 
+  /** The "register a passkey" CTA banner shown when passwordless login is enabled and the user has no passkey yet. */
+  bannerLocator() {
+    return this.page.locator('[data-test-id="register-passkey-banner"]');
+  }
+
+  /**
+   * Follow the banner's call-to-action into the passkey registration wizard and complete it.
+   * Requires a virtual authenticator on the browser context (see helpers/webauthn.ts).
+   */
+  async registerPasskeyFromBanner(name?: string): Promise<void> {
+    await this.bannerLocator().locator('[data-test-id="register-passkey-cta"]').click();
+    if (name) {
+      await this.page.fill('[data-webauthn-register] [data-webauthn-name]', name);
+    }
+    await this.page.locator('[data-webauthn-register] [data-webauthn-trigger]').click();
+    await this.page.locator('.neos-table').waitFor();
+  }
+
   /** Find the table row for the named device and click the delete button, then confirm. */
   async deleteDeviceByName(name: string): Promise<void> {
     const row = this.locatorForDeviceRow(name);
@@ -268,8 +286,14 @@ export class BackendModulePage {
     return this.page.locator('.neos-table tbody tr').filter({ hasText: name });
   }
 
-  /** Locator for table rows of a given type, e.g. "OTP code" or "Security Key". */
+  /**
+   * Locator for table rows of a given type, e.g. "OTP code", "Passkey" or
+   * "Passkey as 2nd factor". Matches the type cell exactly so "Passkey" does not also
+   * match "Passkey as 2nd factor" (substring matching would conflate the two).
+   */
   locatorForDeviceRowsOfType(typeLabel: string) {
-    return this.page.locator('.neos-table tbody tr').filter({ hasText: typeLabel });
+    return this.page.locator('.neos-table tbody tr').filter({
+      has: this.page.getByRole('cell', { name: typeLabel, exact: true }),
+    });
   }
 }

--- a/Tests/E2E/helpers/2fa-pages.ts
+++ b/Tests/E2E/helpers/2fa-pages.ts
@@ -8,24 +8,15 @@ import { generateOtp } from './totp.js';
  */
 const METHOD_LINK_NAME = {
   totp: 'Authenticator app',
-  webauthn: 'Passkey',
+  webauthn: 'Passkey as second factor',
 } as const;
 
 /**
- * Click the WebAuthn registration trigger. When passwordless login is enabled the setup screen
- * offers two buttons — "Register passkey" (discoverable) and "Register security key as 2nd factor"
- * (non-discoverable) — each tagged with data-webauthn-discoverable. We click the one matching the
- * requested discoverability. When passwordless login is disabled there is a single button with no
- * such attribute, so we fall back to the lone trigger.
+ * Click the WebAuthn registration trigger. Each setup screen now shows a single button whose
+ * credential type (discoverable passkey vs. non-discoverable 2nd factor) is fixed by the entry
+ * point that led there, so we just click the lone trigger.
  */
-async function clickWebAuthnRegisterTrigger(page: Page, discoverable: boolean): Promise<void> {
-  const specific = page.locator(
-    `[data-webauthn-register] [data-webauthn-trigger][data-webauthn-discoverable="${discoverable}"]`,
-  );
-  if ((await specific.count()) > 0) {
-    await specific.click();
-    return;
-  }
+async function clickWebAuthnRegisterTrigger(page: Page): Promise<void> {
   await page.locator('[data-webauthn-register] [data-webauthn-trigger]').click();
 }
 
@@ -177,7 +168,7 @@ export class SecondFactorSetupPage {
     if (name) {
       await this.page.fill('[data-webauthn-register] [data-webauthn-name]', name);
     }
-    await clickWebAuthnRegisterTrigger(this.page, true);
+    await clickWebAuthnRegisterTrigger(this.page);
   }
 }
 
@@ -237,31 +228,52 @@ export class BackendModulePage {
    * Add a WebAuthn (security key) device through the new method-picker workflow.
    * Requires a virtual authenticator on the browser context (see helpers/webauthn.ts).
    */
-  async addWebAuthnDevice(name?: string, discoverable: boolean = true): Promise<void> {
+  /**
+   * Add a security-key SECOND FACTOR (non-discoverable) via the "Create second factor" method
+   * picker. Requires a virtual authenticator on the browser context (see helpers/webauthn.ts).
+   * To register a passwordless passkey instead, use registerPasskey().
+   */
+  async addWebAuthnDevice(name?: string): Promise<void> {
     await this.chooseMethod('webauthn');
     if (name) {
       await this.page.fill('[data-webauthn-register] [data-webauthn-name]', name);
     }
-    await clickWebAuthnRegisterTrigger(this.page, discoverable);
+    await clickWebAuthnRegisterTrigger(this.page);
     // Wait for redirect back to the index (table appears)
     await this.page.locator('.neos-table').waitFor();
   }
 
-  /** The "register a passkey" CTA banner shown when passwordless login is enabled and the user has no passkey yet. */
+  /**
+   * Register a passwordless passkey (discoverable) via the "Passkey Registration" section CTA on
+   * the index page. Only available when passwordless login is enabled. Requires a virtual
+   * authenticator on the browser context (see helpers/webauthn.ts).
+   */
+  async registerPasskey(name?: string): Promise<void> {
+    await this.goto();
+    await this.bannerLocator().locator('[data-test-id="register-passkey-cta"]').click();
+    if (name) {
+      await this.page.fill('[data-webauthn-register] [data-webauthn-name]', name);
+    }
+    await clickWebAuthnRegisterTrigger(this.page);
+    await this.page.locator('.neos-table').waitFor();
+  }
+
+  /** The "Passkey Registration" section, shown on the index whenever passwordless login is enabled. */
   bannerLocator() {
     return this.page.locator('[data-test-id="register-passkey-banner"]');
   }
 
   /**
-   * Follow the banner's call-to-action into the passkey registration wizard and complete it.
-   * Requires a virtual authenticator on the browser context (see helpers/webauthn.ts).
+   * Follow the Passkey Registration section's call-to-action into the passkey wizard and complete
+   * it (assumes the index page is already open). Requires a virtual authenticator on the browser
+   * context (see helpers/webauthn.ts).
    */
   async registerPasskeyFromBanner(name?: string): Promise<void> {
     await this.bannerLocator().locator('[data-test-id="register-passkey-cta"]').click();
     if (name) {
       await this.page.fill('[data-webauthn-register] [data-webauthn-name]', name);
     }
-    await clickWebAuthnRegisterTrigger(this.page, true);
+    await clickWebAuthnRegisterTrigger(this.page);
     await this.page.locator('.neos-table').waitFor();
   }
 

--- a/Tests/E2E/helpers/2fa-pages.ts
+++ b/Tests/E2E/helpers/2fa-pages.ts
@@ -12,6 +12,24 @@ const METHOD_LINK_NAME = {
 } as const;
 
 /**
+ * Click the WebAuthn registration trigger. When passwordless login is enabled the setup screen
+ * offers two buttons — "Register passkey" (discoverable) and "Register security key as 2nd factor"
+ * (non-discoverable) — each tagged with data-webauthn-discoverable. We click the one matching the
+ * requested discoverability. When passwordless login is disabled there is a single button with no
+ * such attribute, so we fall back to the lone trigger.
+ */
+async function clickWebAuthnRegisterTrigger(page: Page, discoverable: boolean): Promise<void> {
+  const specific = page.locator(
+    `[data-webauthn-register] [data-webauthn-trigger][data-webauthn-discoverable="${discoverable}"]`,
+  );
+  if ((await specific.count()) > 0) {
+    await specific.click();
+    return;
+  }
+  await page.locator('[data-webauthn-register] [data-webauthn-trigger]').click();
+}
+
+/**
  * The 2FA verification page shown on login when the account already has an
  * enrolled second factor (route: /neos/second-factor-login).
  *
@@ -159,7 +177,7 @@ export class SecondFactorSetupPage {
     if (name) {
       await this.page.fill('[data-webauthn-register] [data-webauthn-name]', name);
     }
-    await this.page.locator('[data-webauthn-register] [data-webauthn-trigger]').click();
+    await clickWebAuthnRegisterTrigger(this.page, true);
   }
 }
 
@@ -219,12 +237,12 @@ export class BackendModulePage {
    * Add a WebAuthn (security key) device through the new method-picker workflow.
    * Requires a virtual authenticator on the browser context (see helpers/webauthn.ts).
    */
-  async addWebAuthnDevice(name?: string): Promise<void> {
+  async addWebAuthnDevice(name?: string, discoverable: boolean = true): Promise<void> {
     await this.chooseMethod('webauthn');
     if (name) {
       await this.page.fill('[data-webauthn-register] [data-webauthn-name]', name);
     }
-    await this.page.locator('[data-webauthn-register] [data-webauthn-trigger]').click();
+    await clickWebAuthnRegisterTrigger(this.page, discoverable);
     // Wait for redirect back to the index (table appears)
     await this.page.locator('.neos-table').waitFor();
   }
@@ -243,7 +261,7 @@ export class BackendModulePage {
     if (name) {
       await this.page.fill('[data-webauthn-register] [data-webauthn-name]', name);
     }
-    await this.page.locator('[data-webauthn-register] [data-webauthn-trigger]').click();
+    await clickWebAuthnRegisterTrigger(this.page, true);
     await this.page.locator('.neos-table').waitFor();
   }
 

--- a/Tests/E2E/helpers/2fa-pages.ts
+++ b/Tests/E2E/helpers/2fa-pages.ts
@@ -9,6 +9,7 @@ import { generateOtp } from './totp.js';
 const METHOD_LINK_NAME = {
   totp: 'Authenticator app',
   webauthn: 'Passkey as second factor',
+  passkey: 'Register a passkey',
 } as const;
 
 /**
@@ -116,6 +117,21 @@ export class SecondFactorSetupPage {
     return this.page.locator('.neos-two-factor__method-picker').isVisible();
   }
 
+  /** The method-picker option (link) with the given accessible name. */
+  methodOption(name: string) {
+    return this.page.getByRole('link', { name, exact: true });
+  }
+
+  /** The "or" separator rendered inside the method picker (between option groups). */
+  methodSeparator() {
+    return this.page.locator('.neos-two-factor__method-picker .neos-two-factor__or-separator');
+  }
+
+  /** The enforcement-explanation notice shown above the method picker on the enforced-setup screen. */
+  enforcedNotice() {
+    return this.page.locator('.neos-two-factor__enforced-notice');
+  }
+
   async chooseTotp() {
     await this.page.getByRole('link', { name: METHOD_LINK_NAME.totp, exact: true }).click();
     await this.page.waitForURL('**/neos/second-factor-setup/totp');
@@ -124,6 +140,12 @@ export class SecondFactorSetupPage {
   async chooseWebAuthn() {
     await this.page.getByRole('link', { name: METHOD_LINK_NAME.webauthn, exact: true }).click();
     await this.page.waitForURL('**/neos/second-factor-setup/webauthn');
+  }
+
+  async choosePasskey() {
+    await this.page.getByRole('link', { name: METHOD_LINK_NAME.passkey, exact: true }).click();
+    // The passkey option carries discoverable=true as a query arg, so match with a trailing wildcard.
+    await this.page.waitForURL('**/neos/second-factor-setup/webauthn**');
   }
 
   async getSecret(): Promise<string> {
@@ -165,6 +187,19 @@ export class SecondFactorSetupPage {
    */
   async setupWebAuthnDevice(name?: string) {
     await this.chooseWebAuthn();
+    if (name) {
+      await this.page.fill('[data-webauthn-register] [data-webauthn-name]', name);
+    }
+    await clickWebAuthnRegisterTrigger(this.page);
+  }
+
+  /**
+   * Walk the passwordless-passkey setup workflow from the method picker: pick the
+   * "Register a passkey" option (discoverable=true) and register. Requires a virtual
+   * authenticator on the browser context (see helpers/webauthn.ts).
+   */
+  async setupPasswordlessPasskey(name?: string) {
+    await this.choosePasskey();
     if (name) {
       await this.page.fill('[data-webauthn-register] [data-webauthn-name]', name);
     }

--- a/Tests/E2E/helpers/general-pages.ts
+++ b/Tests/E2E/helpers/general-pages.ts
@@ -12,6 +12,17 @@ export class NeosLoginPage {
     await this.page.locator('input[type="password"]').fill(password);
     await this.page.locator('.neos-login-btn:not(.neos-disabled):not(.neos-hidden)').click();
   }
+
+  /**
+   * Start the passwordless (usernameless) passkey ceremony from the login screen:
+   * navigate to the login page and click the "Sign in with a passkey" button.
+   * With a virtual authenticator the ceremony auto-resolves and the page redirects
+   * to the backend; the caller asserts the resulting URL.
+   */
+  async signInWithPasskey() {
+    await this.goto();
+    await this.page.locator('[data-webauthn-passwordless] [data-webauthn-trigger]').click();
+  }
 }
 
 export class NeosContentPage {

--- a/Tests/E2E/helpers/system.ts
+++ b/Tests/E2E/helpers/system.ts
@@ -12,10 +12,17 @@ export function createUser(name: string, password: string, roles: string[]) {
 }
 
 export function removeAllUsers() {
-  execSync(
-    `docker exec -u www-data -w /app ${CONTAINER} bash -c "./flow user:delete --assume-yes '*'"`,
-    { stdio: 'ignore', cwd: dirname('.') }
-  )
+  // `./flow user:delete '*'` exits non-zero when there are no users to delete. A teardown
+  // must not fail just because a scenario created no users (e.g. tests that only check the
+  // logged-out login screen), so swallow that error.
+  try {
+    execSync(
+      `docker exec -u www-data -w /app ${CONTAINER} bash -c "./flow user:delete --assume-yes '*'"`,
+      { stdio: 'ignore', cwd: dirname('.') }
+    )
+  } catch {
+    // no users to delete — nothing to clean up
+  }
 }
 
 export async function logout(page: Page) {

--- a/Tests/E2E/helpers/webauthn.ts
+++ b/Tests/E2E/helpers/webauthn.ts
@@ -88,3 +88,26 @@ export async function armWebAuthnCancellation(page: Page): Promise<void> {
     (window as unknown as { __webauthnCancelNext?: boolean }).__webauthnCancelNext = true;
   });
 }
+
+/**
+ * Install a CDP virtual authenticator that models a no-PIN roaming security key (e.g. a YubiKey
+ * with no FIDO2 PIN set): it can prove user *presence* (a touch) but NOT user *verification*, and
+ * it cannot store a resident/discoverable credential. Used to verify that such a key can still be
+ * registered as a plain 2nd factor even while passwordless login is enabled — the case that
+ * previously failed with "User authentication required." because registration forced UV.
+ */
+export async function enableTouchOnlyAuthenticator(page: Page): Promise<string> {
+  const client = await page.context().newCDPSession(page);
+  await client.send('WebAuthn.enable');
+  const { authenticatorId } = await client.send('WebAuthn.addVirtualAuthenticator', {
+    options: {
+      protocol: 'ctap2',
+      transport: 'usb',
+      hasResidentKey: false,
+      hasUserVerification: false,
+      isUserVerified: false,
+      automaticPresenceSimulation: true,
+    },
+  });
+  return authenticatorId;
+}

--- a/Tests/E2E/package-lock.json
+++ b/Tests/E2E/package-lock.json
@@ -123,6 +123,7 @@
       "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-27.2.0.tgz",
       "integrity": "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/uuid": "10.0.0",
         "class-transformer": "0.5.1",
@@ -270,6 +271,7 @@
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },

--- a/Tests/E2E/package.json
+++ b/Tests/E2E/package.json
@@ -8,7 +8,9 @@
     "test:neos8:enforce-all": "npm run generate-tests && SUT=neos8 FLOW_CONTEXT=Production/E2E-SUT/EnforceForAll npx playwright test --grep @enforce-for-all",
     "test:neos8:enforce-role": "npm run generate-tests && SUT=neos8 FLOW_CONTEXT=Production/E2E-SUT/EnforceForRole npx playwright test --grep @enforce-for-role",
     "test:neos8:enforce-provider": "npm run generate-tests && SUT=neos8 FLOW_CONTEXT=Production/E2E-SUT/EnforceForProvider npx playwright test --grep @enforce-for-provider",
+    "test:neos8:passwordless": "npm run generate-tests && SUT=neos8 FLOW_CONTEXT=Production/E2E-SUT/Passwordless npx playwright test --grep @passwordless",
     "test:neos9:defaults": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT npx playwright test --grep @default-context",
+    "test:neos9:passwordless": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT/Passwordless npx playwright test --grep @passwordless",
     "test:neos9:enforce-all": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT/EnforceForAll npx playwright test --grep @enforce-for-all",
     "test:neos9:enforce-role": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT/EnforceForRole npx playwright test --grep @enforce-for-role",
     "test:neos9:enforce-provider": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT/EnforceForProvider npx playwright test --grep @enforce-for-provider"

--- a/Tests/E2E/package.json
+++ b/Tests/E2E/package.json
@@ -5,15 +5,17 @@
   "scripts": {
     "generate-tests": "SUT=notRelevantForBddgen FLOW_CONTEXT=notRelevantForBddgen npx bddgen",
     "test:neos8:defaults": "npm run generate-tests && SUT=neos8 FLOW_CONTEXT=Production/E2E-SUT npx playwright test --grep @default-context",
-    "test:neos8:enforce-all": "npm run generate-tests && SUT=neos8 FLOW_CONTEXT=Production/E2E-SUT/EnforceForAll npx playwright test --grep @enforce-for-all",
+    "test:neos8:enforce-all": "npm run generate-tests && SUT=neos8 FLOW_CONTEXT=Production/E2E-SUT/EnforceForAll npx playwright test --grep '@enforce-for-all$'",
     "test:neos8:enforce-role": "npm run generate-tests && SUT=neos8 FLOW_CONTEXT=Production/E2E-SUT/EnforceForRole npx playwright test --grep @enforce-for-role",
     "test:neos8:enforce-provider": "npm run generate-tests && SUT=neos8 FLOW_CONTEXT=Production/E2E-SUT/EnforceForProvider npx playwright test --grep @enforce-for-provider",
     "test:neos8:passwordless": "npm run generate-tests && SUT=neos8 FLOW_CONTEXT=Production/E2E-SUT/Passwordless npx playwright test --grep @passwordless",
+    "test:neos8:enforce-all-passwordless": "npm run generate-tests && SUT=neos8 FLOW_CONTEXT=Production/E2E-SUT/EnforceForAllPasswordless npx playwright test --grep @enforce-for-all-passwordless",
     "test:neos9:defaults": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT npx playwright test --grep @default-context",
     "test:neos9:passwordless": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT/Passwordless npx playwright test --grep @passwordless",
-    "test:neos9:enforce-all": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT/EnforceForAll npx playwright test --grep @enforce-for-all",
+    "test:neos9:enforce-all": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT/EnforceForAll npx playwright test --grep '@enforce-for-all$'",
     "test:neos9:enforce-role": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT/EnforceForRole npx playwright test --grep @enforce-for-role",
-    "test:neos9:enforce-provider": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT/EnforceForProvider npx playwright test --grep @enforce-for-provider"
+    "test:neos9:enforce-provider": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT/EnforceForProvider npx playwright test --grep @enforce-for-provider",
+    "test:neos9:enforce-all-passwordless": "npm run generate-tests && SUT=neos9 FLOW_CONTEXT=Production/E2E-SUT/EnforceForAllPasswordless npx playwright test --grep @enforce-for-all-passwordless"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/Tests/E2E/playwright.config.ts
+++ b/Tests/E2E/playwright.config.ts
@@ -50,6 +50,11 @@ export default defineConfig({
     // After editing the Dockerfile: Re-run `make setup-sut` to pick up the changes.
     command: `echo "starting system under test ${SUT} with context ${FLOW_CONTEXT}"; FLOW_CONTEXT=${FLOW_CONTEXT} docker compose -f ./system_under_test/${SUT}/docker-compose.yaml up`,
     url: 'http://localhost:8081/',
+    // Reuse an already-running SUT instead of erroring when port 8081 is taken.
+    // The SUT cold-boot re-downloads composer packages (~3-4 min) on every start,
+    // so reusing a healthy container keeps the local dev loop fast. In CI nothing
+    // is listening yet, so Playwright still boots a fresh one.
+    reuseExistingServer: true,
     timeout: 600_000,
     stdout: 'pipe',
     stderr: 'pipe',

--- a/Tests/E2E/steps/2fa-login.steps.ts
+++ b/Tests/E2E/steps/2fa-login.steps.ts
@@ -3,7 +3,7 @@ import { createBdd } from 'playwright-bdd';
 import { BackendModulePage, SecondFactorLoginPage, SecondFactorSetupPage } from '../helpers/2fa-pages.ts';
 import { NeosLoginPage } from "../helpers/general-pages.ts";
 import { createUser, logout } from '../helpers/system.ts';
-import { enableVirtualAuthenticator, armWebAuthnCancellation } from '../helpers/webauthn.ts';
+import { enableVirtualAuthenticator, enableTouchOnlyAuthenticator, armWebAuthnCancellation } from '../helpers/webauthn.ts';
 import { state } from "../helpers/state.ts";
 
 const { Given, When, Then } = createBdd();
@@ -41,6 +41,10 @@ Given('A user with username {string}, password {string} and role {string} with e
 
 Given('I have a virtual security key', async ({ page }) => {
   await enableVirtualAuthenticator(page);
+});
+
+Given('I have a touch-only virtual security key', async ({ page }) => {
+  await enableTouchOnlyAuthenticator(page);
 });
 
 // ── When ──────────────────────────────────────────────────────────────────────

--- a/Tests/E2E/steps/2fa-login.steps.ts
+++ b/Tests/E2E/steps/2fa-login.steps.ts
@@ -76,6 +76,14 @@ When('I set up a WebAuthn 2FA device with name {string}', async ({ page }, devic
   await page.waitForLoadState('networkidle');
 });
 
+When('I set up a passwordless passkey during enforced setup', async ({ page }) => {
+  const setupPage = new SecondFactorSetupPage(page);
+  await setupPage.waitForPage();
+  await setupPage.setupPasswordlessPasskey();
+
+  await page.waitForLoadState('networkidle');
+});
+
 When('I enter a valid TOTP for device {string}', async ({ page }, deviceName: string) => {
   const secret = state.deviceNameSecretMap.get(deviceName);
   if (!secret) throw new Error(`No enrolled TOTP secret found for device "${deviceName}"`);
@@ -147,4 +155,28 @@ Then('I should see the 2FA setup page', async ({ page }) => {
 Then('I should see the 2FA method selection', async ({ page }) => {
   const setupPage = new SecondFactorSetupPage(page);
   expect(await setupPage.isMethodPickerVisible()).toBe(true);
+});
+
+Then('I should see the {string} 2FA method option', async ({ page }, name: string) => {
+  const setupPage = new SecondFactorSetupPage(page);
+  await expect(setupPage.methodOption(name)).toBeVisible();
+});
+
+Then('I should not see the {string} 2FA method option', async ({ page }, name: string) => {
+  const setupPage = new SecondFactorSetupPage(page);
+  await expect(setupPage.methodOption(name)).toBeHidden();
+});
+
+Then('I should see a separator between the passkey option and the other 2FA methods', async ({ page }) => {
+  const setupPage = new SecondFactorSetupPage(page);
+  await expect(setupPage.methodSeparator()).toBeVisible();
+});
+
+Then('I should see the enforced 2FA setup notice', async ({ page }) => {
+  const setupPage = new SecondFactorSetupPage(page);
+  await expect(setupPage.enforcedNotice()).toBeVisible();
+});
+
+Then('I should see a 2FA section heading {string}', async ({ page }, heading: string) => {
+  await expect(page.getByRole('heading', { name: heading, exact: true })).toBeVisible();
 });

--- a/Tests/E2E/steps/backend-module.steps.ts
+++ b/Tests/E2E/steps/backend-module.steps.ts
@@ -30,6 +30,11 @@ When('I add a new WebAuthn 2FA device with name {string}', async ({ page }, devi
   await modulePage.addWebAuthnDevice(deviceName);
 });
 
+When('I add a new WebAuthn 2nd-factor device with name {string}', async ({ page }, deviceName: string) => {
+  const modulePage = new BackendModulePage(page);
+  await modulePage.addWebAuthnDevice(deviceName, false);
+});
+
 When('I try to remove the 2FA device with the name {string}',
   async ({ page }, name: string) => {
     const modulePage = new BackendModulePage(page);

--- a/Tests/E2E/steps/backend-module.steps.ts
+++ b/Tests/E2E/steps/backend-module.steps.ts
@@ -71,3 +71,15 @@ Then('There should be {int} enrolled {string} 2FA device(s)',
     await expect(modulePage.locatorForDeviceRowsOfType(typeLabel)).toHaveCount(parseInt(countStr, 10));
   },
 );
+
+Then('I should see the register-a-passkey banner', async ({ page }) => {
+  await expect(new BackendModulePage(page).bannerLocator()).toBeVisible();
+});
+
+When('I register a passkey from the banner', async ({ page }) => {
+  await new BackendModulePage(page).registerPasskeyFromBanner();
+});
+
+Then('I should not see the register-a-passkey banner', async ({ page }) => {
+  await expect(new BackendModulePage(page).bannerLocator()).toHaveCount(0);
+});

--- a/Tests/E2E/steps/backend-module.steps.ts
+++ b/Tests/E2E/steps/backend-module.steps.ts
@@ -32,7 +32,17 @@ When('I add a new WebAuthn 2FA device with name {string}', async ({ page }, devi
 
 When('I add a new WebAuthn 2nd-factor device with name {string}', async ({ page }, deviceName: string) => {
   const modulePage = new BackendModulePage(page);
-  await modulePage.addWebAuthnDevice(deviceName, false);
+  await modulePage.addWebAuthnDevice(deviceName);
+});
+
+When('I register a passkey', async ({ page }) => {
+  const modulePage = new BackendModulePage(page);
+  await modulePage.registerPasskey();
+});
+
+When('I register a passkey with name {string}', async ({ page }, deviceName: string) => {
+  const modulePage = new BackendModulePage(page);
+  await modulePage.registerPasskey(deviceName);
 });
 
 When('I try to remove the 2FA device with the name {string}',
@@ -76,6 +86,10 @@ Then('There should be {int} enrolled {string} 2FA device(s)',
     await expect(modulePage.locatorForDeviceRowsOfType(typeLabel)).toHaveCount(parseInt(countStr, 10));
   },
 );
+
+Then('I should see a section titled {string}', async ({ page }, title: string) => {
+  await expect(page.locator('legend', { hasText: title })).toBeVisible();
+});
 
 Then('I should see the register-a-passkey banner', async ({ page }) => {
   await expect(new BackendModulePage(page).bannerLocator()).toBeVisible();

--- a/Tests/E2E/steps/general-login.steps.ts
+++ b/Tests/E2E/steps/general-login.steps.ts
@@ -28,6 +28,30 @@ When('I log out', async ({ page }) => {
   await logout(page);
 });
 
+When('I sign in with a passkey', async ({ page }) => {
+  const loginPage = new NeosLoginPage(page);
+  await loginPage.signInWithPasskey();
+  await page.waitForLoadState('networkidle');
+});
+
+When('I open the login page', async ({ page }) => {
+  await new NeosLoginPage(page).goto();
+});
+
+Then('I should not see the passkey sign-in button', async ({ page }) => {
+  await expect(page.locator('[data-webauthn-passwordless]')).toHaveCount(0);
+});
+
+Then('the passwordless verify endpoint is forbidden', async ({ page }) => {
+  // The endpoint must reject everyone while passwordless login is disabled — server-side,
+  // not just by hiding the button.
+  const response = await page.request.post('/neos/passwordless-webauthn/verify', {
+    data: { assertion: '{}' },
+    failOnStatusCode: false,
+  });
+  expect(response.status()).toBe(403);
+});
+
 When('I open {string} while logged out', async ({ page }, path: string) => {
   // Requesting a protected backend URL while unauthenticated makes Neos remember
   // it as the intercepted request and bounce to the login form. After the (2FA)

--- a/Tests/E2E/steps/general-login.steps.ts
+++ b/Tests/E2E/steps/general-login.steps.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 import { NeosLoginPage, NeosContentPage } from '../helpers/general-pages.ts';
 import { createUser, logout } from '../helpers/system.ts';
+import { armWebAuthnCancellation } from '../helpers/webauthn.ts';
 
 const { Given, When, Then } = createBdd();
 
@@ -36,6 +37,17 @@ When('I sign in with a passkey', async ({ page }) => {
 
 When('I open the login page', async ({ page }) => {
   await new NeosLoginPage(page).goto();
+});
+
+When('I start a passkey sign-in but cancel it', async ({ page }) => {
+  // Arm the one-shot cancellation before navigating, so the assertion rejects with
+  // NotAllowedError (as if the user dismissed the OS passkey prompt) instead of the
+  // virtual authenticator silently approving it. webauthn.js then reveals the error
+  // tooltip and the page stays on the login screen.
+  await armWebAuthnCancellation(page);
+  await new NeosLoginPage(page).goto();
+  await page.locator('[data-webauthn-passwordless] [data-webauthn-trigger]').click();
+  await page.locator('[data-webauthn-passwordless] [data-webauthn-error]').waitFor({ state: 'visible' });
 });
 
 Then('I should not see the passkey sign-in button', async ({ page }) => {

--- a/Tests/E2E/system_under_test/neos8/entrypoint.sh
+++ b/Tests/E2E/system_under_test/neos8/entrypoint.sh
@@ -19,6 +19,10 @@ echo "Database is ready."
 
 yes y | ./flow resource:clean || true
 
+# Make the boot idempotent: the DB lives in a persistent named volume, so re-importing the demo
+# site on a re-boot would fail/duplicate. Prune first — a harmless no-op on a fresh DB.
+./flow site:prune --confirmation true || true
+
 ./flow site:import --package-key Neos.Demo
 
 ./flow resource:publish --collection static

--- a/Tests/E2E/system_under_test/neos9/entrypoint.sh
+++ b/Tests/E2E/system_under_test/neos9/entrypoint.sh
@@ -22,6 +22,11 @@ yes y | ./flow resource:clean || true
 ./flow cr:setup
 ./flow cr:status
 
+# Make the boot idempotent: the DB lives in a persistent named volume, so on a re-boot the event
+# store already holds the demo site and `site:importall` would fail with a ConcurrencyException
+# ("content stream ... already contains events"). Prune first — a harmless no-op on a fresh DB.
+yes y | ./flow site:pruneAll || true
+
 ./flow site:importall --package-key Neos.Demo
 
 ./flow resource:publish --collection static

--- a/Tests/E2E/system_under_test/sut-base-docker-compose.yaml
+++ b/Tests/E2E/system_under_test/sut-base-docker-compose.yaml
@@ -31,6 +31,9 @@ services:
       - ../../../Configuration:/app/DistributionPackages/Sandstorm.NeosTwoFactorAuthentication/Configuration:cached
       - ../../../Migrations:/app/DistributionPackages/Sandstorm.NeosTwoFactorAuthentication/Migrations:cached
       - ../../../Resources:/app/DistributionPackages/Sandstorm.NeosTwoFactorAuthentication/Resources:cached
+      # Tests are mounted so the package's PHPUnit unit/functional tests can run inside the SUT
+      # (the E2E Playwright suite lives here too but runs from the host).
+      - ../../../Tests:/app/DistributionPackages/Sandstorm.NeosTwoFactorAuthentication/Tests:cached
       - ../../../composer.json:/app/DistributionPackages/Sandstorm.NeosTwoFactorAuthentication/composer.json:cached
     networks:
       - neos_SUT

--- a/Tests/E2E/system_under_test/sut_file_system_overrides/app/Configuration/Production/E2E-SUT/EnforceForAllPasswordless/Settings.2FA.yaml
+++ b/Tests/E2E/system_under_test/sut_file_system_overrides/app/Configuration/Production/E2E-SUT/EnforceForAllPasswordless/Settings.2FA.yaml
@@ -1,0 +1,11 @@
+Sandstorm:
+  NeosTwoFactorAuthentication:
+    # enforce 2FA for all users AND allow passwordless passkey login — this variant exercises
+    # the combination: a factor-less user forced to set up 2FA can enrol a discoverable,
+    # usernameless passkey right at the enforced-setup gate and then log in passwordlessly.
+    enforceTwoFactorAuthentication: true
+    webAuthn:
+      passwordlessLoginEnabled: true
+      # Governs the 2nd-factor (non-discoverable) path only; passkey registration hard-requires
+      # user verification in code regardless. Kept 'discouraged' so touch-only keys also work.
+      userVerification: 'discouraged'

--- a/Tests/E2E/system_under_test/sut_file_system_overrides/app/Configuration/Production/E2E-SUT/Passwordless/Settings.2FA.yaml
+++ b/Tests/E2E/system_under_test/sut_file_system_overrides/app/Configuration/Production/E2E-SUT/Passwordless/Settings.2FA.yaml
@@ -4,6 +4,8 @@ Sandstorm:
       # Opt-in to passwordless (usernameless) passkey login for this E2E variant.
       # Off by default; this variant exercises the enabled path.
       passwordlessLoginEnabled: true
-      # Passwordless usernameless login requires user verification; the virtual
-      # authenticator used in the E2E suite supports it.
-      userVerification: 'required'
+      # Governs the 2nd-factor (non-discoverable) path only. Passkey registration and passwordless
+      # usernameless login already hard-require user verification in code, so 'discouraged' here
+      # does not weaken them — it lets this variant also exercise registering a touch-only security
+      # key as a plain 2nd factor alongside passkeys.
+      userVerification: 'discouraged'

--- a/Tests/E2E/system_under_test/sut_file_system_overrides/app/Configuration/Production/E2E-SUT/Passwordless/Settings.2FA.yaml
+++ b/Tests/E2E/system_under_test/sut_file_system_overrides/app/Configuration/Production/E2E-SUT/Passwordless/Settings.2FA.yaml
@@ -1,0 +1,9 @@
+Sandstorm:
+  NeosTwoFactorAuthentication:
+    webAuthn:
+      # Opt-in to passwordless (usernameless) passkey login for this E2E variant.
+      # Off by default; this variant exercises the enabled path.
+      passwordlessLoginEnabled: true
+      # Passwordless usernameless login requires user verification; the virtual
+      # authenticator used in the E2E suite supports it.
+      userVerification: 'required'

--- a/Tests/Unit/Service/SecondFactorSessionStorageServiceTest.php
+++ b/Tests/Unit/Service/SecondFactorSessionStorageServiceTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Sandstorm\NeosTwoFactorAuthentication\Tests\Unit\Service;
+
+use Neos\Flow\Session\SessionInterface;
+use Neos\Flow\Session\SessionManagerInterface;
+use Neos\Flow\Tests\UnitTestCase;
+use Sandstorm\NeosTwoFactorAuthentication\Domain\AuthenticationStatus;
+use Sandstorm\NeosTwoFactorAuthentication\Service\SecondFactorSessionStorageService;
+
+/**
+ * Unit tests for the package's session storage.
+ *
+ * Regression coverage for the passwordless-ceremony bug: a logged-out visitor who starts a
+ * passwordless login writes `webAuthnPasswordlessOptions` into the shared session container
+ * (via {@see SecondFactorSessionStorageService::putValue()}) but never an authentication status.
+ * If that ceremony is abandoned, a later regular login must not trip over the half-populated
+ * container.
+ *
+ * The tests back the mocked {@see SessionInterface} with a real in-memory array so they exercise
+ * observable behavior (write options -> read status) rather than mock call sequences.
+ */
+class SecondFactorSessionStorageServiceTest extends UnitTestCase
+{
+    private SecondFactorSessionStorageService $service;
+
+    /**
+     * The session's data store, keyed exactly like Flow's real session
+     * (top-level key -> value), so the whole package container lives under SESSION_OBJECT_ID.
+     *
+     * @var array<string, mixed>
+     */
+    private array $sessionData;
+
+    private bool $sessionStarted;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sessionData = [];
+        $this->sessionStarted = true;
+
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('isStarted')->willReturnCallback(fn() => $this->sessionStarted);
+        $session->method('start')->willReturnCallback(function () {
+            $this->sessionStarted = true;
+        });
+        $session->method('getData')->willReturnCallback(fn(string $key) => $this->sessionData[$key] ?? null);
+        $session->method('hasKey')->willReturnCallback(fn(string $key) => array_key_exists($key, $this->sessionData));
+        $session->method('putData')->willReturnCallback(function (string $key, mixed $data) {
+            $this->sessionData[$key] = $data;
+        });
+
+        $sessionManager = $this->createMock(SessionManagerInterface::class);
+        $sessionManager->method('getCurrentSession')->willReturn($session);
+
+        $this->service = new SecondFactorSessionStorageService();
+        $this->inject($this->service, 'sessionManager', $sessionManager);
+    }
+
+    /**
+     * The container exists (it holds abandoned passwordless options) but carries no
+     * authentication status. Reading the status must yield AUTHENTICATION_NEEDED, not crash
+     * on the `string` return type with a `null`.
+     *
+     * @test
+     */
+    public function getAuthenticationStatusReturnsAuthenticationNeededWhenStatusKeyMissing(): void
+    {
+        $this->sessionData[SecondFactorSessionStorageService::SESSION_OBJECT_ID] = [
+            SecondFactorSessionStorageService::SESSION_OBJECT_WEBAUTHN_PASSWORDLESS_OPTIONS => '{"challenge":"x"}',
+        ];
+
+        self::assertSame(
+            AuthenticationStatus::AUTHENTICATION_NEEDED,
+            $this->service->getAuthenticationStatus()
+        );
+    }
+
+    /**
+     * The real abandoned-ceremony sequence: a passwordless login seeds the container with only its
+     * options, then initialization runs on the next (regular) login. Initialization must recognise
+     * the missing status and set it — keying off the status key, not merely the container's presence.
+     *
+     * @test
+     */
+    public function initializeSetsStatusWhenContainerExistsWithoutStatus(): void
+    {
+        $this->service->startSessionIfNotStarted();
+        $this->service->putValue(
+            SecondFactorSessionStorageService::SESSION_OBJECT_WEBAUTHN_PASSWORDLESS_OPTIONS,
+            '{"challenge":"x"}'
+        );
+
+        $this->service->initializeTwoFactorSessionObject();
+
+        $container = $this->sessionData[SecondFactorSessionStorageService::SESSION_OBJECT_ID];
+        self::assertSame(
+            AuthenticationStatus::AUTHENTICATION_NEEDED,
+            $container[SecondFactorSessionStorageService::SESSION_OBJECT_AUTH_STATUS] ?? null,
+            'initialization must set the authentication status when it is missing'
+        );
+        self::assertSame(
+            '{"challenge":"x"}',
+            $container[SecondFactorSessionStorageService::SESSION_OBJECT_WEBAUTHN_PASSWORDLESS_OPTIONS] ?? null,
+            'initialization must preserve the already-stored passwordless options'
+        );
+    }
+
+    /**
+     * Initialization must be idempotent: a completed login (status AUTHENTICATED) must never be
+     * downgraded back to AUTHENTICATION_NEEDED by a subsequent request re-running initialization.
+     *
+     * @test
+     */
+    public function initializeDoesNotOverwriteExistingAuthenticatedStatus(): void
+    {
+        $this->service->setAuthenticationStatus(AuthenticationStatus::AUTHENTICATED);
+
+        $this->service->initializeTwoFactorSessionObject();
+
+        self::assertSame(AuthenticationStatus::AUTHENTICATED, $this->service->getAuthenticationStatus());
+    }
+
+    /**
+     * The original happy path: a fresh session with no package container gets initialized to
+     * AUTHENTICATION_NEEDED.
+     *
+     * @test
+     */
+    public function initializeInitialisesFreshSessionToNeeded(): void
+    {
+        $this->service->initializeTwoFactorSessionObject();
+
+        self::assertSame(AuthenticationStatus::AUTHENTICATION_NEEDED, $this->service->getAuthenticationStatus());
+    }
+}

--- a/Tests/Unit/Service/WebAuthnServiceTest.php
+++ b/Tests/Unit/Service/WebAuthnServiceTest.php
@@ -5,7 +5,9 @@ namespace Sandstorm\NeosTwoFactorAuthentication\Tests\Unit\Service;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Tests\UnitTestCase;
+use Sandstorm\NeosTwoFactorAuthentication\Service\PublicKeyCredentialSourceRepositoryAdapter;
 use Sandstorm\NeosTwoFactorAuthentication\Service\WebAuthnService;
+use Webauthn\AuthenticatorSelectionCriteria;
 
 /**
  * Unit tests for the security-critical mapping from a passkey user handle to a Neos backend
@@ -66,5 +68,115 @@ class WebAuthnServiceTest extends UnitTestCase
 
         $this->expectException(\RuntimeException::class);
         $this->service->resolveBackendAccountByUserHandle('the-user-handle');
+    }
+
+    /**
+     * Configure the service for registration-option tests: inject the WebAuthn settings and a
+     * credential-source repository that reports no already-registered credentials, and return a
+     * minimal backend account.
+     */
+    private function configureRegistrationService(bool $passwordlessLoginEnabled, string $userVerification = 'discouraged'): Account
+    {
+        $this->inject($this->service, 'relyingPartyName', 'Neos Backend');
+        $this->inject($this->service, 'relyingPartyId', null);
+        $this->inject($this->service, 'userVerification', $userVerification);
+        $this->inject($this->service, 'timeoutMs', 60000);
+        $this->inject($this->service, 'passwordlessLoginEnabled', $passwordlessLoginEnabled);
+
+        $credentialSourceRepository = $this->createMock(PublicKeyCredentialSourceRepositoryAdapter::class);
+        $credentialSourceRepository->method('findAllForUserEntity')->willReturn([]);
+        $this->inject($this->service, 'credentialSourceRepository', $credentialSourceRepository);
+
+        $account = $this->createMock(Account::class);
+        $account->method('getAccountIdentifier')->willReturn('admin');
+        $this->persistenceManager->method('getIdentifierByObject')->willReturn('the-user-handle');
+
+        return $account;
+    }
+
+    /**
+     * The 2nd-factor path must stay touch-friendly even while passwordless login is enabled:
+     * registering with discoverable=false must NOT demand a resident key or user verification, so
+     * a no-PIN security key (touch only) can register. This is the regression that produced the
+     * "User authentication required." 400.
+     *
+     * @test
+     */
+    public function registersTouchOnlySecondFactorWhilePasswordlessEnabled(): void
+    {
+        $account = $this->configureRegistrationService(passwordlessLoginEnabled: true, userVerification: 'discouraged');
+
+        $options = $this->service->createRegistrationOptions($account, 'localhost', discoverable: false);
+
+        self::assertNotSame(
+            AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED,
+            $options->authenticatorSelection?->residentKey,
+            'A 2nd-factor registration must not require a resident key.'
+        );
+        self::assertSame(
+            'discouraged',
+            $options->authenticatorSelection?->userVerification,
+            'A 2nd-factor registration must use the configured user-verification level, not force it.'
+        );
+    }
+
+    /**
+     * The passkey path is unchanged: opting into a discoverable passkey while passwordless login
+     * is enabled forces a resident key and user verification (a verified passkey is itself a full
+     * multi-factor login).
+     *
+     * @test
+     */
+    public function registersDiscoverablePasskeyWhilePasswordlessEnabled(): void
+    {
+        $account = $this->configureRegistrationService(passwordlessLoginEnabled: true, userVerification: 'discouraged');
+
+        $options = $this->service->createRegistrationOptions($account, 'localhost', discoverable: true);
+
+        self::assertSame(
+            AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED,
+            $options->authenticatorSelection?->residentKey,
+        );
+        self::assertSame(
+            AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED,
+            $options->authenticatorSelection?->userVerification,
+        );
+    }
+
+    /**
+     * Guard: a discoverable passkey can never be minted while passwordless login is disabled, even
+     * if the client asks for one — the credential stays a plain, configured-UV 2nd factor.
+     *
+     * @test
+     */
+    public function ignoresDiscoverableRequestWhilePasswordlessDisabled(): void
+    {
+        $account = $this->configureRegistrationService(passwordlessLoginEnabled: false, userVerification: 'discouraged');
+
+        $options = $this->service->createRegistrationOptions($account, 'localhost', discoverable: true);
+
+        self::assertNotSame(
+            AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED,
+            $options->authenticatorSelection?->residentKey,
+        );
+        self::assertSame('discouraged', $options->authenticatorSelection?->userVerification);
+    }
+
+    /**
+     * The stored `discoverable` flag is derived from the registration options at verify time
+     * (single source of truth), so it round-trips with the choice made at options time: a passkey
+     * registration is discoverable, a 2nd-factor registration is not.
+     *
+     * @test
+     */
+    public function discoverabilityIsDerivedFromTheRegistrationOptions(): void
+    {
+        $account = $this->configureRegistrationService(passwordlessLoginEnabled: true);
+
+        $passkeyOptions = $this->service->createRegistrationOptions($account, 'localhost', discoverable: true);
+        $secondFactorOptions = $this->service->createRegistrationOptions($account, 'localhost', discoverable: false);
+
+        self::assertTrue($this->service->isDiscoverableRegistration($passkeyOptions));
+        self::assertFalse($this->service->isDiscoverableRegistration($secondFactorOptions));
     }
 }

--- a/Tests/Unit/Service/WebAuthnServiceTest.php
+++ b/Tests/Unit/Service/WebAuthnServiceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Sandstorm\NeosTwoFactorAuthentication\Tests\Unit\Service;
+
+use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\Security\Account;
+use Neos\Flow\Tests\UnitTestCase;
+use Sandstorm\NeosTwoFactorAuthentication\Service\WebAuthnService;
+
+/**
+ * Unit tests for the security-critical mapping from a passkey user handle to a Neos backend
+ * account, used by passwordless login. This is the guard that ensures only Neos backend
+ * accounts can authenticate through the usernameless passkey path.
+ */
+class WebAuthnServiceTest extends UnitTestCase
+{
+    private WebAuthnService $service;
+
+    /**
+     * @var PersistenceManagerInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $persistenceManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new WebAuthnService();
+        $this->persistenceManager = $this->createMock(PersistenceManagerInterface::class);
+        $this->inject($this->service, 'persistenceManager', $this->persistenceManager);
+    }
+
+    /**
+     * @test
+     */
+    public function resolvesBackendAccountByUserHandle(): void
+    {
+        $account = $this->createMock(Account::class);
+        $account->method('getAuthenticationProviderName')->willReturn('Neos.Neos:Backend');
+        $this->persistenceManager
+            ->method('getObjectByIdentifier')
+            ->with('the-user-handle', Account::class)
+            ->willReturn($account);
+
+        self::assertSame($account, $this->service->resolveBackendAccountByUserHandle('the-user-handle'));
+    }
+
+    /**
+     * @test
+     */
+    public function throwsWhenNoAccountExistsForUserHandle(): void
+    {
+        $this->persistenceManager->method('getObjectByIdentifier')->willReturn(null);
+
+        $this->expectException(\RuntimeException::class);
+        $this->service->resolveBackendAccountByUserHandle('unknown-handle');
+    }
+
+    /**
+     * @test
+     */
+    public function throwsWhenAccountIsNotANeosBackendAccount(): void
+    {
+        $account = $this->createMock(Account::class);
+        $account->method('getAuthenticationProviderName')->willReturn('Some.Other:Provider');
+        $this->persistenceManager->method('getObjectByIdentifier')->willReturn($account);
+
+        $this->expectException(\RuntimeException::class);
+        $this->service->resolveBackendAccountByUserHandle('the-user-handle');
+    }
+}


### PR DESCRIPTION
Add config-opt-in option for passkey login support for Neos (username-less and password-less).

- multiple passkeys allowed per user
- can exist in parallel to username/password and second factors - also with webAuthn

Needs a database migration: `./flow doctrine:migrate`

Needs to be tested in production with different passkey providers:
- Browsers (Chrome, Firefox, Safari...)
- Password Managers