### PR TITLE
TASK: Fix composer install for Neos9 SUT

### DIFF
--- a/Tests/E2E/system_under_test/Dockerfile
+++ b/Tests/E2E/system_under_test/Dockerfile
@@ -25,7 +25,7 @@ RUN \
 # Install Neos base distribution
 ARG NEOS_VERSION
 RUN rm -rf /app \
-  && composer create-project neos/neos-base-distribution:^${NEOS_VERSION} /app
+  && composer create-project --stability dev neos/neos-base-distribution:^${NEOS_VERSION} /app
 
 # Add config files
 # NOTE: must run AFTER `create-project`, since that does `rm -rf /app` and would


### PR DESCRIPTION
With Neos 9.1 and upwards some Neos packages (e.g. `neos/buildessentials`) are only published as dev branches. 
With that composer fails to install with a "minimum stability exception".
Fix: Allow dev while still preferring stable releases where they exist.